### PR TITLE
Integrate vetkeys to current app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arrayref"
@@ -81,9 +81,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "candid"
-version = "0.10.17"
+version = "0.10.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaac522d18020d5fbc8320ecb12a9b13b2137ae31133da2d42fa256a825507c4"
+checksum = "3ae495fbaf9ee8f4f7898affbd3df85dba8598bfa4ffaca24726c42aa4beb7b1"
 dependencies = [
  "anyhow",
  "binread",
@@ -99,35 +99,36 @@ dependencies = [
  "serde",
  "serde_bytes",
  "stacker",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "candid_derive"
-version = "0.10.17"
+version = "0.10.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1b4fddbd462182050989068d53604a91a3d0f117c3c8316c6818023df00add"
+checksum = "7388be3b345b1a2ad30e529619b4db0d1955852afb56da821fa6a805f7cbf6be"
 dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.31"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cpufeatures"
@@ -164,6 +165,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +222,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -193,6 +230,117 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -212,8 +360,42 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -222,44 +404,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "ic-cdk"
-version = "0.17.2"
+name = "hex-literal"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a7344f41493cbf591f13ae9f90181076f808a83af799815c3074b19c693d2e"
+checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "ic-cdk"
+version = "0.18.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efb278f5d3ef033b3eed7f01f1096eaf67701896aa5ef69f5eddf5a84833dc0"
 dependencies = [
  "candid",
  "ic-cdk-executor",
  "ic-cdk-macros",
+ "ic-error-types",
+ "ic-management-canister-types",
  "ic0",
  "serde",
  "serde_bytes",
+ "slotmap",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "ic-cdk-executor"
-version = "0.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903057edd3d4ff4b3fe44a64eaee1ceb73f579ba29e3ded372b63d291d7c16c2"
+checksum = "99f4ee8930fd2e491177e2eb7fff53ee1c407c13b9582bdc7d6920cf83109a2d"
+dependencies = [
+ "ic0",
+ "slotmap",
+]
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.17.2"
+version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cbaa50fa36d3e0616114becf81faa95a099e0d60948ed6978f30f1c77399fd"
+checksum = "7eb14c5d691cc9d72bb95459b4761e3a4b3444b85a63d17555d5ddd782969a1e"
 dependencies = [
  "candid",
+ "darling",
  "proc-macro2",
  "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "ic-error-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbeeb3d91aa179d6496d7293becdacedfc413c825cac79fd54ea1906f003ee55"
+dependencies = [
  "serde",
- "serde_tokenstream",
- "syn 2.0.104",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "ic-ledger-types"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7103dea96107c8b1e49d6e80ab452ab48e9f3594d618dbb46449381f4f0a01"
+checksum = "feb52826a353b583012628af6da762b52672350686c3275234febfadeca965ea"
 dependencies = [
  "candid",
  "crc32fast",
@@ -271,10 +495,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic0"
-version = "0.23.0"
+name = "ic-management-canister-types"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
+checksum = "ea7e5b8a0f7c3b320d9450ac950547db4f24a31601b5d398f9680b64427455d2"
+dependencies = [
+ "candid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-stable-structures"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54aeb082293c69def5ab34c70593ba85ff000386f7d0eacdf73514daaeca031"
+dependencies = [
+ "ic_principal",
+]
+
+[[package]]
+name = "ic-vetkeys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89db8e638924d9e07dd8fa33dc5cfcdc69b7331bed7fcc72e2586f3956b12e58"
+dependencies = [
+ "anyhow",
+ "candid",
+ "futures",
+ "hex-literal",
+ "hkdf",
+ "ic-cdk",
+ "ic-cdk-macros",
+ "ic-stable-structures",
+ "ic_bls12_381",
+ "lazy_static",
+ "pairing",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "sha2 0.10.9",
+ "sha3",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ic0"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1499d08fd5be8f790d477e1865d63bab6a8d748300e141270c4296e6d5fdd6bc"
+
+[[package]]
+name = "ic_bls12_381"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e828f9e804ccefe4b9b15b2195f474c60fd4f95ccd14fcb554eb6d7dfafde3"
+dependencies = [
+ "digest 0.10.7",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "ic_principal"
@@ -286,7 +575,22 @@ dependencies = [
  "data-encoding",
  "serde",
  "sha2 0.10.9",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -303,9 +607,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libsecp256k1"
@@ -320,7 +624,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
 ]
@@ -353,6 +657,12 @@ checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "num-bigint"
@@ -390,10 +700,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -417,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -438,9 +769,11 @@ name = "q3x_backend"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "getrandom 0.2.16",
  "hex",
  "ic-cdk",
  "ic-ledger-types",
+ "ic-vetkeys",
  "libsecp256k1",
  "serde",
  "sha2 0.10.9",
@@ -462,11 +795,22 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -476,7 +820,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -485,7 +839,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -494,14 +857,14 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "serde"
@@ -522,6 +885,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,19 +902,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "serde_tokenstream"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -569,10 +930,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "stacker"
@@ -585,6 +971,52 @@ dependencies = [
  "libc",
  "psm",
  "windows-sys",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -606,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -621,7 +1053,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -632,7 +1073,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -658,9 +1110,9 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-width"
@@ -679,6 +1131,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "windows-sys"
@@ -755,20 +1213,40 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 candid = "0.10.7"
-ic-cdk = "0.17.2"
+ic-cdk = "0.18.2"
 serde = "1.0.219"
 serde_derive = "1.0.219"
 sha2 = "0.10.9"
@@ -13,4 +13,8 @@ libsecp256k1 = { version = "0.6.0", package = "libsecp256k1", default-features =
 	"lazy-static-context",
 ] }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-ic-ledger-types = "0.14.0"
+ic-ledger-types = "0.15.0"
+ic-vetkeys = "0.4.0"
+
+# Force override getrandom
+getrandom = { version = "0.2", features = ["custom"] }

--- a/src/README.md
+++ b/src/README.md
@@ -23,9 +23,9 @@ dfx start --clean
 
 ### Step 2: Determine ledger file locations
 
-The URL for the ledger Wasm module is `https://github.com/dfinity/ic/releases/download/ledger-suite-icp-2025-07-04/ledger.did`.
+The URL for the ledger Wasm module is `https://github.com/dfinity/ic/releases/download/ledger-suite-icp-2025-07-04/ledger-canister_notify-method.wasm.gz`.
 
-The URL for the ledger.did file is `https://github.com/dfinity/ic/releases/download/ledger-suite-icp-2025-07-04/ledger-canister_notify-method.wasm.gz`.
+The URL for the ledger.did file is `https://github.com/dfinity/ic/releases/download/ledger-suite-icp-2025-07-04/ledger.did`.
 
 ## Step 3: Configure the `dfx.json` file to use the ledger
 

--- a/src/declarations/q3x_backend/index.js
+++ b/src/declarations/q3x_backend/index.js
@@ -10,7 +10,7 @@ export { idlFactory } from "./q3x_backend.did.js";
  * beginning in dfx 0.15.0
  */
 export const canisterId =
-  process.env.CANISTER_ID_q3x_BACKEND;
+  process.env.CANISTER_ID_Q3X_BACKEND;
 
 export const createActor = (canisterId, options = {}) => {
   const agent = options.agent || new HttpAgent({ ...options.agentOptions });

--- a/src/declarations/q3x_backend/q3x_backend.did
+++ b/src/declarations/q3x_backend/q3x_backend.did
@@ -1,38 +1,192 @@
+type Result = variant { Ok; Err : text };
+type Result_1 = variant { Ok : text; Err : text };
+type Result_2 = variant { Ok : nat8; Err : text };
+type Result_3 = variant { Ok : vec text; Err : text };
+type Result_4 = variant { Ok : vec record { text; vec text }; Err : text };
+type Result_5 = variant { Ok : bool; Err : text };
 type Wallet = record {
-    signers: vec principal;
-    threshold: nat8;
-    message_queue: vec record { vec nat8; vec principal; }
+  threshold : nat8;
+  metadata : vec record { blob; text };
+  signers : vec text;
+  message_queue : vec record { blob; vec text };
 };
-
-type Message = record {
-    message: text;
-    signers: vec principal;
-};
-
 service : (text) -> {
-    create_wallet: (text, vec principal, nat8) -> (variant { Ok; Err: text });
-    get_wallet: (text) ->  (opt Wallet);
-    can_sign: (text, text) -> (bool);
-    propose: (text, text) -> (variant { Ok; Err: text });
-    approve: (text, text) -> (variant { Ok: nat8; Err: text });
-    sign: (text, text) -> (variant { Ok: text; Err: text });
-    verify_signature: (text, text, text) -> (variant { Ok: bool; Err: text });
-    eth_address : (text) -> (variant { Ok: text ; Err: text });
-
-    get_messages_to_sign: (text) -> (variant { Ok: vec text; Err: text });
-    get_proposed_messages: (text) -> (variant { Ok: vec text; Err: text });
-    get_messages_with_signers: (text) -> (variant { Ok: vec record { text; vec principal };  Err: text });
-
-    add_signer: (text, principal) -> (variant { Ok: text; Err: text });
-    remove_signer: (text, principal) -> (variant { Ok: text; Err: text });
-    set_threshold: (text, nat8) -> (variant { Ok: text; Err: text });
-
-    get_wallets_for_principal: (principal) -> (vec text);
-
-    add_metadata: (text, text, text) -> (variant { Ok; Err: text });
-    get_metadata: (text, text) -> (variant { Ok: text; Err: text });
-
-    propose_with_metadata: (text, text, text) -> (variant { Ok; Err: text });
-
+  // Add metadata to a message in the wallet.
+  // 
+  // * `message` - The message as a `Vec<u8>`.
+  // * `metadata` - The metadata as a `String`.
+  // * `caller` - The `Principal` of the caller.
+  // 
+  // Returns `Result<(), String>` indicating success or the type of failure.
+  add_metadata : (text, text, text) -> (Result);
+  // Proposes adding a new signer to the wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // * `new_signer` - The Principal of the new signer to add.
+  // 
+  // # Returns
+  // 
+  // * `Result<(), String>` - Result indicating success or an error message.
+  add_signer : (text, principal) -> (Result_1);
+  // Approves a message for signing in the wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // * `msg` - The message to be approved, in hexadecimal format.
+  // 
+  // # Returns
+  // 
+  // * `Result<u8, String>` - The number of signatures or an error message.
+  approve : (text, text) -> (Result_2);
+  // Checks if a message can be signed by the wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // * `msg` - The message to be checked, in hexadecimal format.
+  // 
+  // # Returns
+  // 
+  // * `bool` - True if the message can be signed, otherwise false.
+  can_sign : (text, text) -> (bool) query;
+  // Creates a new wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - Unique identifier for the wallet as a String.
+  // * `signers` - A list of Principals representing the signers of the wallet.
+  // * `threshold` - The threshold number of signers required for a transaction.
+  // 
+  // # Returns
+  // 
+  // * `Result<(), String>` - Result indicating success or an error message.
+  create_wallet : (text, vec principal, nat8) -> (Result);
+  // Retrieves all messages that can be signed for a given wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // 
+  // # Returns
+  // 
+  // * `Vec<Vec<u8>>` - A list of messages that can be signed.
+  get_messages_to_sign : (text) -> (Result_3);
+  // Retrieves all messages that have been proposed along with their signers for a given wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // 
+  // # Returns
+  // 
+  // * `Vec<(Vec<u8>, Vec<Principal>)>` - A list of tuples containing messages and their signers.
+  get_messages_with_signers : (text) -> (Result_4) query;
+  // Get the metadata associated with a message in the wallet.
+  // 
+  // * `message` - The message as a `Vec<u8>`.
+  // 
+  // Returns `Option<&String>` containing the metadata if it exists.
+  get_metadata : (text, text) -> (Result_1) query;
+  // Retrieves all messages that have been proposed for a given wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // 
+  // # Returns
+  // 
+  // * `Vec<Vec<u8>>` - A list of messages that have been proposed.
+  get_proposed_messages : (text) -> (Result_3) query;
+  // Retrieves a wallet by its ID.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The unique identifier for the wallet as a String.
+  // 
+  // # Returns
+  // 
+  // * `Option<Wallet>` - The wallet if found, otherwise None.
+  get_wallet : (text) -> (opt Wallet);
+  // Retrieves all wallets associated with a given principal.
+  // 
+  // # Arguments
+  // 
+  // * `principal` - The principal to retrieve wallets for.
+  // 
+  // # Returns
+  // 
+  // * `Vec<String>` - A list of wallet IDs associated with the principal.
+  get_wallets_for_principal : (principal) -> (vec text) query;
+  // Proposes a message to be signed by the wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // * `msg` - The message to be proposed, in hexadecimal format.
+  // 
+  // # Returns
+  // 
+  // * `Result<(), String>` - Result indicating success or an error message.
+  propose : (text, text) -> (Result);
+  // Proposes a message and adds metadata in one call.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // * `msg` - The message to be proposed, in hexadecimal format.
+  // * `metadata` - The metadata to be added to the message.
+  // 
+  // # Returns
+  // 
+  // * `Result<(), String>` - Result indicating success or an error message.
+  propose_with_metadata : (text, text, text) -> (Result);
+  // Proposes removing a signer from the wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // * `signer_to_remove` - The Principal of the signer to remove.
+  // 
+  // # Returns
+  // 
+  // * `Result<(), String>` - Result indicating success or an error message.
+  remove_signer : (text, principal) -> (Result_1);
+  // Proposes setting a new threshold for the wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // * `new_threshold` - The new threshold value to set.
+  // 
+  // # Returns
+  // 
+  // * `Result<String, String>` - Result indicating success or an error message.
+  set_threshold : (text, nat8) -> (Result_1);
+  // Signs a message using the wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // * `msg` - The message to be signed, in hexadecimal format.
+  // 
+  // # Returns
+  // 
+  // * `Result<String, String>` - The signature in hexadecimal format or an error message.
+  sign : (text, text) -> (Result_1);
+  transfer : (text, nat64, principal) -> (Result_1);
+  // Verifies a signature for a given message and wallet.
+  // 
+  // # Arguments
+  // 
+  // * `wallet_id` - The wallet's unique identifier.
+  // * `message` - The message associated with the signature, in hexadecimal format.
+  // * `signature` - The signature to be verified, in hexadecimal format.
+  // 
+  // # Returns
+  // 
+  // * `Result<bool, String>` - True if the signature is valid, otherwise an error message.
+  verify_signature : (text, text, text) -> (Result_5);
 }
-

--- a/src/declarations/q3x_backend/q3x_backend.did.d.ts
+++ b/src/declarations/q3x_backend/q3x_backend.did.d.ts
@@ -2,87 +2,237 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
-export interface Message { 'signers' : Array<Principal>, 'message' : string }
+export type Result = { 'Ok' : null } |
+  { 'Err' : string };
+export type Result_1 = { 'Ok' : string } |
+  { 'Err' : string };
+export type Result_2 = { 'Ok' : number } |
+  { 'Err' : string };
+export type Result_3 = { 'Ok' : Array<string> } |
+  { 'Err' : string };
+export type Result_4 = { 'Ok' : Array<[string, Array<string>]> } |
+  { 'Err' : string };
+export type Result_5 = { 'Ok' : boolean } |
+  { 'Err' : string };
 export interface Wallet {
   'threshold' : number,
-  'signers' : Array<Principal>,
-  'message_queue' : Array<[Uint8Array | number[], Array<Principal>]>,
+  'metadata' : Array<[Uint8Array | number[], string]>,
+  'signers' : Array<string>,
+  'message_queue' : Array<[Uint8Array | number[], Array<string>]>,
 }
 export interface _SERVICE {
-  'add_metadata' : ActorMethod<
-    [string, string, string],
-    { 'Ok' : null } |
-      { 'Err' : string }
-  >,
-  'add_signer' : ActorMethod<
-    [string, Principal],
-    { 'Ok' : string } |
-      { 'Err' : string }
-  >,
-  'approve' : ActorMethod<
-    [string, string],
-    { 'Ok' : number } |
-      { 'Err' : string }
-  >,
+  /**
+   * Add metadata to a message in the wallet.
+   * 
+   * * `message` - The message as a `Vec<u8>`.
+   * * `metadata` - The metadata as a `String`.
+   * * `caller` - The `Principal` of the caller.
+   * 
+   * Returns `Result<(), String>` indicating success or the type of failure.
+   */
+  'add_metadata' : ActorMethod<[string, string, string], Result>,
+  /**
+   * Proposes adding a new signer to the wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * * `new_signer` - The Principal of the new signer to add.
+   * 
+   * # Returns
+   * 
+   * * `Result<(), String>` - Result indicating success or an error message.
+   */
+  'add_signer' : ActorMethod<[string, Principal], Result_1>,
+  /**
+   * Approves a message for signing in the wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * * `msg` - The message to be approved, in hexadecimal format.
+   * 
+   * # Returns
+   * 
+   * * `Result<u8, String>` - The number of signatures or an error message.
+   */
+  'approve' : ActorMethod<[string, string], Result_2>,
+  /**
+   * Checks if a message can be signed by the wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * * `msg` - The message to be checked, in hexadecimal format.
+   * 
+   * # Returns
+   * 
+   * * `bool` - True if the message can be signed, otherwise false.
+   */
   'can_sign' : ActorMethod<[string, string], boolean>,
-  'create_wallet' : ActorMethod<
-    [string, Array<Principal>, number],
-    { 'Ok' : null } |
-      { 'Err' : string }
-  >,
-  'eth_address' : ActorMethod<[string], { 'Ok' : string } | { 'Err' : string }>,
-  'get_messages_to_sign' : ActorMethod<
-    [string],
-    { 'Ok' : Array<string> } |
-      { 'Err' : string }
-  >,
-  'get_messages_with_signers' : ActorMethod<
-    [string],
-    { 'Ok' : Array<[string, Array<Principal>]> } |
-      { 'Err' : string }
-  >,
-  'get_metadata' : ActorMethod<
-    [string, string],
-    { 'Ok' : string } |
-      { 'Err' : string }
-  >,
-  'get_proposed_messages' : ActorMethod<
-    [string],
-    { 'Ok' : Array<string> } |
-      { 'Err' : string }
-  >,
+  /**
+   * Creates a new wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - Unique identifier for the wallet as a String.
+   * * `signers` - A list of Principals representing the signers of the wallet.
+   * * `threshold` - The threshold number of signers required for a transaction.
+   * 
+   * # Returns
+   * 
+   * * `Result<(), String>` - Result indicating success or an error message.
+   */
+  'create_wallet' : ActorMethod<[string, Array<Principal>, number], Result>,
+  /**
+   * Retrieves all messages that can be signed for a given wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * 
+   * # Returns
+   * 
+   * * `Vec<Vec<u8>>` - A list of messages that can be signed.
+   */
+  'get_messages_to_sign' : ActorMethod<[string], Result_3>,
+  /**
+   * Retrieves all messages that have been proposed along with their signers for a given wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * 
+   * # Returns
+   * 
+   * * `Vec<(Vec<u8>, Vec<Principal>)>` - A list of tuples containing messages and their signers.
+   */
+  'get_messages_with_signers' : ActorMethod<[string], Result_4>,
+  /**
+   * Get the metadata associated with a message in the wallet.
+   * 
+   * * `message` - The message as a `Vec<u8>`.
+   * 
+   * Returns `Option<&String>` containing the metadata if it exists.
+   */
+  'get_metadata' : ActorMethod<[string, string], Result_1>,
+  /**
+   * Retrieves all messages that have been proposed for a given wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * 
+   * # Returns
+   * 
+   * * `Vec<Vec<u8>>` - A list of messages that have been proposed.
+   */
+  'get_proposed_messages' : ActorMethod<[string], Result_3>,
+  /**
+   * Retrieves a wallet by its ID.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The unique identifier for the wallet as a String.
+   * 
+   * # Returns
+   * 
+   * * `Option<Wallet>` - The wallet if found, otherwise None.
+   */
   'get_wallet' : ActorMethod<[string], [] | [Wallet]>,
+  /**
+   * Retrieves all wallets associated with a given principal.
+   * 
+   * # Arguments
+   * 
+   * * `principal` - The principal to retrieve wallets for.
+   * 
+   * # Returns
+   * 
+   * * `Vec<String>` - A list of wallet IDs associated with the principal.
+   */
   'get_wallets_for_principal' : ActorMethod<[Principal], Array<string>>,
-  'propose' : ActorMethod<
-    [string, string],
-    { 'Ok' : null } |
-      { 'Err' : string }
-  >,
-  'propose_with_metadata' : ActorMethod<
-    [string, string, string],
-    { 'Ok' : null } |
-      { 'Err' : string }
-  >,
-  'remove_signer' : ActorMethod<
-    [string, Principal],
-    { 'Ok' : string } |
-      { 'Err' : string }
-  >,
-  'set_threshold' : ActorMethod<
-    [string, number],
-    { 'Ok' : string } |
-      { 'Err' : string }
-  >,
-  'sign' : ActorMethod<
-    [string, string],
-    { 'Ok' : string } |
-      { 'Err' : string }
-  >,
-  'verify_signature' : ActorMethod<
-    [string, string, string],
-    { 'Ok' : boolean } |
-      { 'Err' : string }
-  >,
+  /**
+   * Proposes a message to be signed by the wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * * `msg` - The message to be proposed, in hexadecimal format.
+   * 
+   * # Returns
+   * 
+   * * `Result<(), String>` - Result indicating success or an error message.
+   */
+  'propose' : ActorMethod<[string, string], Result>,
+  /**
+   * Proposes a message and adds metadata in one call.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * * `msg` - The message to be proposed, in hexadecimal format.
+   * * `metadata` - The metadata to be added to the message.
+   * 
+   * # Returns
+   * 
+   * * `Result<(), String>` - Result indicating success or an error message.
+   */
+  'propose_with_metadata' : ActorMethod<[string, string, string], Result>,
+  /**
+   * Proposes removing a signer from the wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * * `signer_to_remove` - The Principal of the signer to remove.
+   * 
+   * # Returns
+   * 
+   * * `Result<(), String>` - Result indicating success or an error message.
+   */
+  'remove_signer' : ActorMethod<[string, Principal], Result_1>,
+  /**
+   * Proposes setting a new threshold for the wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * * `new_threshold` - The new threshold value to set.
+   * 
+   * # Returns
+   * 
+   * * `Result<String, String>` - Result indicating success or an error message.
+   */
+  'set_threshold' : ActorMethod<[string, number], Result_1>,
+  /**
+   * Signs a message using the wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * * `msg` - The message to be signed, in hexadecimal format.
+   * 
+   * # Returns
+   * 
+   * * `Result<String, String>` - The signature in hexadecimal format or an error message.
+   */
+  'sign' : ActorMethod<[string, string], Result_1>,
+  'transfer' : ActorMethod<[string, bigint, Principal], Result_1>,
+  /**
+   * Verifies a signature for a given message and wallet.
+   * 
+   * # Arguments
+   * 
+   * * `wallet_id` - The wallet's unique identifier.
+   * * `message` - The message associated with the signature, in hexadecimal format.
+   * * `signature` - The signature to be verified, in hexadecimal format.
+   * 
+   * # Returns
+   * 
+   * * `Result<bool, String>` - True if the signature is valid, otherwise an error message.
+   */
+  'verify_signature' : ActorMethod<[string, string, string], Result_5>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/q3x_backend/q3x_backend.did.js
+++ b/src/declarations/q3x_backend/q3x_backend.did.js
@@ -1,97 +1,52 @@
 export const idlFactory = ({ IDL }) => {
+  const Result = IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Text });
+  const Result_1 = IDL.Variant({ 'Ok' : IDL.Text, 'Err' : IDL.Text });
+  const Result_2 = IDL.Variant({ 'Ok' : IDL.Nat8, 'Err' : IDL.Text });
+  const Result_3 = IDL.Variant({ 'Ok' : IDL.Vec(IDL.Text), 'Err' : IDL.Text });
+  const Result_4 = IDL.Variant({
+    'Ok' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Text))),
+    'Err' : IDL.Text,
+  });
   const Wallet = IDL.Record({
     'threshold' : IDL.Nat8,
-    'signers' : IDL.Vec(IDL.Principal),
-    'message_queue' : IDL.Vec(
-      IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Vec(IDL.Principal))
-    ),
+    'metadata' : IDL.Vec(IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Text)),
+    'signers' : IDL.Vec(IDL.Text),
+    'message_queue' : IDL.Vec(IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Vec(IDL.Text))),
   });
+  const Result_5 = IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : IDL.Text });
   return IDL.Service({
-    'add_metadata' : IDL.Func(
-        [IDL.Text, IDL.Text, IDL.Text],
-        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Text })],
-        [],
-      ),
-    'add_signer' : IDL.Func(
-        [IDL.Text, IDL.Principal],
-        [IDL.Variant({ 'Ok' : IDL.Text, 'Err' : IDL.Text })],
-        [],
-      ),
-    'approve' : IDL.Func(
-        [IDL.Text, IDL.Text],
-        [IDL.Variant({ 'Ok' : IDL.Nat8, 'Err' : IDL.Text })],
-        [],
-      ),
-    'can_sign' : IDL.Func([IDL.Text, IDL.Text], [IDL.Bool], []),
+    'add_metadata' : IDL.Func([IDL.Text, IDL.Text, IDL.Text], [Result], []),
+    'add_signer' : IDL.Func([IDL.Text, IDL.Principal], [Result_1], []),
+    'approve' : IDL.Func([IDL.Text, IDL.Text], [Result_2], []),
+    'can_sign' : IDL.Func([IDL.Text, IDL.Text], [IDL.Bool], ['query']),
     'create_wallet' : IDL.Func(
         [IDL.Text, IDL.Vec(IDL.Principal), IDL.Nat8],
-        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Text })],
+        [Result],
         [],
       ),
-    'eth_address' : IDL.Func(
-        [IDL.Text],
-        [IDL.Variant({ 'Ok' : IDL.Text, 'Err' : IDL.Text })],
-        [],
-      ),
-    'get_messages_to_sign' : IDL.Func(
-        [IDL.Text],
-        [IDL.Variant({ 'Ok' : IDL.Vec(IDL.Text), 'Err' : IDL.Text })],
-        [],
-      ),
-    'get_messages_with_signers' : IDL.Func(
-        [IDL.Text],
-        [
-          IDL.Variant({
-            'Ok' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Principal))),
-            'Err' : IDL.Text,
-          }),
-        ],
-        [],
-      ),
-    'get_metadata' : IDL.Func(
-        [IDL.Text, IDL.Text],
-        [IDL.Variant({ 'Ok' : IDL.Text, 'Err' : IDL.Text })],
-        [],
-      ),
-    'get_proposed_messages' : IDL.Func(
-        [IDL.Text],
-        [IDL.Variant({ 'Ok' : IDL.Vec(IDL.Text), 'Err' : IDL.Text })],
-        [],
-      ),
+    'get_messages_to_sign' : IDL.Func([IDL.Text], [Result_3], []),
+    'get_messages_with_signers' : IDL.Func([IDL.Text], [Result_4], ['query']),
+    'get_metadata' : IDL.Func([IDL.Text, IDL.Text], [Result_1], ['query']),
+    'get_proposed_messages' : IDL.Func([IDL.Text], [Result_3], ['query']),
     'get_wallet' : IDL.Func([IDL.Text], [IDL.Opt(Wallet)], []),
     'get_wallets_for_principal' : IDL.Func(
         [IDL.Principal],
         [IDL.Vec(IDL.Text)],
-        [],
+        ['query'],
       ),
-    'propose' : IDL.Func(
-        [IDL.Text, IDL.Text],
-        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Text })],
-        [],
-      ),
+    'propose' : IDL.Func([IDL.Text, IDL.Text], [Result], []),
     'propose_with_metadata' : IDL.Func(
         [IDL.Text, IDL.Text, IDL.Text],
-        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Text })],
+        [Result],
         [],
       ),
-    'remove_signer' : IDL.Func(
-        [IDL.Text, IDL.Principal],
-        [IDL.Variant({ 'Ok' : IDL.Text, 'Err' : IDL.Text })],
-        [],
-      ),
-    'set_threshold' : IDL.Func(
-        [IDL.Text, IDL.Nat8],
-        [IDL.Variant({ 'Ok' : IDL.Text, 'Err' : IDL.Text })],
-        [],
-      ),
-    'sign' : IDL.Func(
-        [IDL.Text, IDL.Text],
-        [IDL.Variant({ 'Ok' : IDL.Text, 'Err' : IDL.Text })],
-        [],
-      ),
+    'remove_signer' : IDL.Func([IDL.Text, IDL.Principal], [Result_1], []),
+    'set_threshold' : IDL.Func([IDL.Text, IDL.Nat8], [Result_1], []),
+    'sign' : IDL.Func([IDL.Text, IDL.Text], [Result_1], []),
+    'transfer' : IDL.Func([IDL.Text, IDL.Nat64, IDL.Principal], [Result_1], []),
     'verify_signature' : IDL.Func(
         [IDL.Text, IDL.Text, IDL.Text],
-        [IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : IDL.Text })],
+        [Result_5],
         [],
       ),
   });

--- a/src/q3x_backend/Cargo.toml
+++ b/src/q3x_backend/Cargo.toml
@@ -15,3 +15,5 @@ hex = { workspace = true }
 libsecp256k1 = { workspace = true }
 tiny-keccak = { workspace = true }
 ic-ledger-types = { workspace = true }
+ic-vetkeys = { workspace = true }
+getrandom = { workspace = true }

--- a/src/q3x_backend/q3x_backend.did
+++ b/src/q3x_backend/q3x_backend.did
@@ -2,13 +2,13 @@ type Result = variant { Ok; Err : text };
 type Result_1 = variant { Ok : text; Err : text };
 type Result_2 = variant { Ok : nat8; Err : text };
 type Result_3 = variant { Ok : vec text; Err : text };
-type Result_4 = variant { Ok : vec record { text; vec principal }; Err : text };
+type Result_4 = variant { Ok : vec record { text; vec text }; Err : text };
 type Result_5 = variant { Ok : bool; Err : text };
 type Wallet = record {
   threshold : nat8;
   metadata : vec record { blob; text };
-  signers : vec principal;
-  message_queue : vec record { blob; vec principal };
+  signers : vec text;
+  message_queue : vec record { blob; vec text };
 };
 service : (text) -> {
   // Add metadata to a message in the wallet.
@@ -51,7 +51,7 @@ service : (text) -> {
   // # Returns
   // 
   // * `bool` - True if the message can be signed, otherwise false.
-  can_sign : (text, text) -> (bool) query;
+  can_sign : (text, text) -> (bool);
   // Creates a new wallet.
   // 
   // # Arguments
@@ -73,7 +73,7 @@ service : (text) -> {
   // # Returns
   // 
   // * `Vec<Vec<u8>>` - A list of messages that can be signed.
-  get_messages_to_sign : (text) -> (Result_3) query;
+  get_messages_to_sign : (text) -> (Result_3);
   // Retrieves all messages that have been proposed along with their signers for a given wallet.
   // 
   // # Arguments
@@ -83,13 +83,13 @@ service : (text) -> {
   // # Returns
   // 
   // * `Vec<(Vec<u8>, Vec<Principal>)>` - A list of tuples containing messages and their signers.
-  get_messages_with_signers : (text) -> (Result_4) query;
+  get_messages_with_signers : (text) -> (Result_4);
   // Get the metadata associated with a message in the wallet.
   // 
   // * `message` - The message as a `Vec<u8>`.
   // 
   // Returns `Option<&String>` containing the metadata if it exists.
-  get_metadata : (text, text) -> (Result_1) query;
+  get_metadata : (text, text) -> (Result_1);
   // Retrieves all messages that have been proposed for a given wallet.
   // 
   // # Arguments
@@ -99,7 +99,7 @@ service : (text) -> {
   // # Returns
   // 
   // * `Vec<Vec<u8>>` - A list of messages that have been proposed.
-  get_proposed_messages : (text) -> (Result_3) query;
+  get_proposed_messages : (text) -> (Result_3);
   // Retrieves a wallet by its ID.
   // 
   // # Arguments
@@ -109,7 +109,7 @@ service : (text) -> {
   // # Returns
   // 
   // * `Option<Wallet>` - The wallet if found, otherwise None.
-  get_wallet : (text) -> (opt Wallet) query;
+  get_wallet : (text) -> (opt Wallet);
   // Retrieves all wallets associated with a given principal.
   // 
   // # Arguments

--- a/src/q3x_backend/src/lib.rs
+++ b/src/q3x_backend/src/lib.rs
@@ -1,23 +1,27 @@
 mod ecdsa;
+mod privacy;
+mod vetkey;
 mod wallet;
 
+use crate::privacy::{
+    decrypt_wallet_data, encrypt_message_with_vetkeys, encrypt_principals_with_vetkeys,
+};
+use crate::vetkey::set_vetkey_id;
 use crate::wallet::{MultiSignatureWallet, TransferArgs, Wallet, WalletError};
-//use candid::Principal;
 use ic_cdk::api::management_canister::ecdsa::EcdsaKeyId;
-use ic_cdk::{caller, init, query, update};
+use ic_cdk::{init, query, update};
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::str::FromStr;
 
 use crate::ecdsa::{get_ecdsa_key_id_from_env, is_signature_valid, sign_message};
 
 use candid::Principal;
 
-//use ic_cdk::update;
 use ic_ledger_types::Tokens;
 
 type WalletStore = BTreeMap<String, Wallet>;
-type PrincipalWalletsMap = BTreeMap<Principal, Vec<String>>;
+type PrincipalWalletsMap = BTreeMap<Principal, HashSet<String>>; // use HashSet because we don't want duplicate wallet ids
 
 thread_local! {
     static PRINCIPAL_WALLETS_MAP: RefCell<PrincipalWalletsMap> = RefCell::default();
@@ -32,6 +36,7 @@ const WALLET_INVALID_SIGNATURE_ERROR: &str = "WalletInvalidSignature";
 const WALLET_CANNOT_SIGN_ERROR: &str = "WalletCannotSign";
 const WALLET_SIGNERS_NOT_MATCH_THRESHOLD: &str = "WalletSignersNotMatchThreshold";
 const METADATA_NOT_FOUND: &str = "MetadataNotFound";
+const ENCRYPTION_ERROR: &str = "EncryptionError";
 
 /// Initializes the module with environment-specific configurations.
 ///
@@ -42,6 +47,7 @@ const METADATA_NOT_FOUND: &str = "MetadataNotFound";
 /// # Behavior
 ///
 /// Initializes the KEY_ID with an EcdsaKeyId based on the provided environment.
+/// Initializes VetKD key ID for encryption/decryption operations based on the provided environment.
 #[init]
 fn init(env: String) {
     KEY_ID.with(|key_id| {
@@ -49,6 +55,9 @@ fn init(env: String) {
             .borrow_mut()
             .clone_from(&get_ecdsa_key_id_from_env(&env));
     });
+
+    // Initialize VetKD key for encryption/decryption
+    set_vetkey_id(&env);
 }
 
 /// Creates a new wallet.
@@ -63,14 +72,22 @@ fn init(env: String) {
 ///
 /// * `Result<(), String>` - Result indicating success or an error message.
 #[update]
-fn create_wallet(wallet_id: String, signers: Vec<Principal>, threshold: u8) -> Result<(), String> {
+async fn create_wallet(
+    wallet_id: String,
+    signers: Vec<Principal>,
+    threshold: u8,
+) -> Result<(), String> {
     if WALLETS.with(|wallets| wallets.borrow().contains_key(&wallet_id)) {
         return Err(WALLET_ALREADY_EXISTS_ERROR.to_string());
     }
 
+    let encrypted_signers = encrypt_principals_with_vetkeys(&signers, &wallet_id)
+        .await
+        .map_err(|e| format!("Failed to encrypt signers: {}", e))?;
+
     let mut wallet = Wallet::default();
-    signers.iter().for_each(|signer| {
-        wallet.add_signer(*signer);
+    encrypted_signers.iter().for_each(|signer| {
+        wallet.add_signer_principal_hex(signer.clone());
     });
 
     if wallet.set_default_threshold(threshold).is_err() {
@@ -83,11 +100,11 @@ fn create_wallet(wallet_id: String, signers: Vec<Principal>, threshold: u8) -> R
     });
 
     // Now, use the original wallet and wallet_id
-    for signer in wallet.get_signers() {
+    for signer in signers {
         let wallet_id_clone = wallet_id.clone(); // Clone wallet_id for use in the closure
         PRINCIPAL_WALLETS_MAP.with(|map| {
             let mut map = map.borrow_mut();
-            map.entry(signer).or_default().push(wallet_id_clone);
+            map.entry(signer).or_default().insert(wallet_id_clone);
         });
     }
     Ok(())
@@ -102,9 +119,33 @@ fn create_wallet(wallet_id: String, signers: Vec<Principal>, threshold: u8) -> R
 /// # Returns
 ///
 /// * `Option<Wallet>` - The wallet if found, otherwise None.
-#[query]
-fn get_wallet(wallet_id: String) -> Option<Wallet> {
-    WALLETS.with(|wallets| wallets.borrow().get(&wallet_id).cloned())
+#[update]
+async fn get_wallet(wallet_id: String) -> Option<Wallet> {
+    let wallet = WALLETS.with(|wallets| wallets.borrow().get(&wallet_id).cloned());
+
+    if let Some(wallet) = wallet {
+        if wallet.has_signer(&wallet_id).await {
+            // Authorized - return decrypted wallet
+            match decrypt_wallet_data(
+                &wallet.get_signers(),
+                &wallet.get_default_threshold(),
+                &wallet.get_encrypted_messages_with_signers(),
+                &wallet.get_all_metadata(),
+                &wallet_id,
+            )
+            .await
+            {
+                Ok(decrypted_wallet) => Some(decrypted_wallet),
+                Err(_) => Some(wallet),
+            }
+        } else {
+            // Not authorized - return encrypted wallet
+            Some(wallet)
+        }
+    } else {
+        // Wallet not found
+        None
+    }
 }
 
 /// Proposes a message to be signed by the wallet.
@@ -118,22 +159,29 @@ fn get_wallet(wallet_id: String) -> Option<Wallet> {
 ///
 /// * `Result<(), String>` - Result indicating success or an error message.
 #[update]
-fn propose(wallet_id: String, msg: String) -> Result<(), String> {
+async fn propose(wallet_id: String, msg: String) -> Result<(), String> {
     debug_println_caller("propose");
     let msg = hex::decode(msg).map_err(|_| "InvalidMessage".to_string())?;
+
+    let mut wallet = WALLETS
+        .with(|wallets| wallets.borrow().get(&wallet_id).cloned())
+        .ok_or_else(|| WALLET_NOT_FOUND_ERROR.to_string())?;
+
+    wallet
+        .propose_message(msg, &wallet_id)
+        .await
+        .map_err(|error| match error {
+            WalletError::InvalidSignature => WALLET_INVALID_SIGNATURE_ERROR.to_string(),
+            WalletError::MsgAlreadyQueued => WALLET_MSG_ALREADY_QUEUED_ERROR.to_string(),
+            WalletError::EncryptionError => ENCRYPTION_ERROR.to_string(),
+            _ => "UnknownError".to_string(),
+        })?;
+
     WALLETS.with(|wallets| {
-        wallets
-            .borrow_mut()
-            .get_mut(&wallet_id)
-            .ok_or(WALLET_NOT_FOUND_ERROR.to_string())
-            .unwrap()
-            .propose_message(caller(), msg)
-            .map_err(|error| match error {
-                WalletError::MsgAlreadyQueued => WALLET_MSG_ALREADY_QUEUED_ERROR.to_string(),
-                WalletError::InvalidSignature => WALLET_INVALID_SIGNATURE_ERROR.to_string(),
-                _ => "UnknownError".to_string(),
-            })
-    })
+        wallets.borrow_mut().insert(wallet_id, wallet);
+    });
+
+    Ok(())
 }
 
 /// Checks if a message can be signed by the wallet.
@@ -146,19 +194,22 @@ fn propose(wallet_id: String, msg: String) -> Result<(), String> {
 /// # Returns
 ///
 /// * `bool` - True if the message can be signed, otherwise false.
-#[query]
-fn can_sign(wallet_id: String, msg: String) -> bool {
-    match hex::decode(&msg) {
-        Ok(decoded_msg) => WALLETS.with(|wallets| {
-            wallets
-                .borrow()
-                .get(&wallet_id)
-                .ok_or(WALLET_NOT_FOUND_ERROR.to_string())
-                .unwrap()
-                .can_sign(&decoded_msg)
-        }),
-        Err(_) => false,
-    }
+#[update]
+async fn can_sign(wallet_id: String, msg: String) -> bool {
+    let decode_msg = hex::decode(&msg).unwrap_or_default();
+    let encrypted_message = match encrypt_message_with_vetkeys(&decode_msg, &wallet_id).await {
+        Ok(msg) => msg,
+        Err(_) => return false,
+    };
+
+    WALLETS.with(|wallets| {
+        wallets
+            .borrow()
+            .get(&wallet_id)
+            .ok_or(WALLET_NOT_FOUND_ERROR.to_string())
+            .unwrap()
+            .can_sign(&encrypted_message)
+    })
 }
 
 /// Approves a message for signing in the wallet.
@@ -172,22 +223,29 @@ fn can_sign(wallet_id: String, msg: String) -> bool {
 ///
 /// * `Result<u8, String>` - The number of signatures or an error message.
 #[update]
-fn approve(wallet_id: String, msg: String) -> Result<u8, String> {
+async fn approve(wallet_id: String, msg: String) -> Result<u8, String> {
     debug_println_caller("approve");
     let msg = hex::decode(msg).map_err(|_| "InvalidMessage".to_string())?;
 
+    let mut wallet = WALLETS
+        .with(|wallets| wallets.borrow().get(&wallet_id).cloned())
+        .ok_or_else(|| WALLET_NOT_FOUND_ERROR.to_string())?;
+
+    let result = wallet
+        .approve(msg, &wallet_id)
+        .await
+        .map_err(|error| match error {
+            WalletError::MsgNotQueued => "WalletMsgNotQueued".to_string(),
+            WalletError::InvalidSignature => WALLET_INVALID_SIGNATURE_ERROR.to_string(),
+            WalletError::MsgAlreadySignedBySigner => "WalletMsgAlreadySignedBySigner".to_string(),
+            _ => "UnknownError".to_string(),
+        })?;
+
     WALLETS.with(|wallets| {
-        wallets
-            .borrow_mut()
-            .get_mut(&wallet_id)
-            .ok_or(WALLET_NOT_FOUND_ERROR.to_string())?
-            .approve(msg, caller())
-            .map_err(|error| match error {
-                WalletError::MsgNotQueued => "WalletMsgNotQueued".to_string(),
-                WalletError::InvalidSignature => WALLET_INVALID_SIGNATURE_ERROR.to_string(),
-                _ => "UnknownError".to_string(),
-            })
-    })
+        wallets.borrow_mut().insert(wallet_id, wallet);
+    });
+
+    Ok(result)
 }
 
 /// Signs a message using the wallet.
@@ -202,7 +260,11 @@ fn approve(wallet_id: String, msg: String) -> Result<u8, String> {
 /// * `Result<String, String>` - The signature in hexadecimal format or an error message.
 #[update]
 async fn sign(wallet_id: String, msg: String) -> Result<String, String> {
-    let msg = hex::decode(msg).map_err(|_| "InvalidMessage".to_string())?;
+    let msg: Vec<u8> = hex::decode(msg).map_err(|_| "InvalidMessage".to_string())?;
+
+    let encrypted_message = encrypt_message_with_vetkeys(&msg, &wallet_id)
+        .await
+        .map_err(|_| "EncryptionError".to_string())?;
 
     let can_sign = WALLETS.with(|wallets| {
         wallets
@@ -210,7 +272,7 @@ async fn sign(wallet_id: String, msg: String) -> Result<String, String> {
             .get(&wallet_id)
             .ok_or(WALLET_NOT_FOUND_ERROR.to_string())
             .unwrap()
-            .can_sign(&msg)
+            .can_sign(&encrypted_message)
     });
 
     let key_id = KEY_ID.with(|key_id| key_id.borrow().clone());
@@ -220,6 +282,9 @@ async fn sign(wallet_id: String, msg: String) -> Result<String, String> {
     }
     let mut is_special_message = false;
     let mut pending_transfer: Option<(Wallet, TransferArgs)> = None;
+    let mut pending_add_signer: Option<Principal> = None;
+    let mut pending_remove_signer: Option<Principal> = None;
+
     if let Ok(message_str) = String::from_utf8(msg.clone()) {
         WALLETS.with(|wallets| {
             let mut wallets = wallets.borrow_mut();
@@ -234,23 +299,13 @@ async fn sign(wallet_id: String, msg: String) -> Result<String, String> {
             if message_str.starts_with("ADD_SIGNER::") {
                 let new_signer_str = &message_str["ADD_SIGNER::".len()..];
                 if let Ok(new_signer) = Principal::from_str(new_signer_str) {
-                    wallet.add_signer(new_signer);
-                    PRINCIPAL_WALLETS_MAP.with(|map| {
-                        let mut map = map.borrow_mut();
-                        map.entry(new_signer).or_default().push(wallet_id.clone());
-                    });
+                    pending_add_signer = Some(new_signer);
                 }
                 is_special_message = true;
             } else if message_str.starts_with("REMOVE_SIGNER::") {
                 let signer_to_remove_str = &message_str["REMOVE_SIGNER::".len()..];
                 if let Ok(signer_to_remove) = Principal::from_str(signer_to_remove_str) {
-                    wallet.remove_signer(signer_to_remove);
-                    PRINCIPAL_WALLETS_MAP.with(|map| {
-                        let mut map = map.borrow_mut();
-                        if let Some(wallets) = map.get_mut(&signer_to_remove) {
-                            wallets.retain(|id| id != &wallet_id);
-                        }
-                    });
+                    pending_remove_signer = Some(signer_to_remove);
                 }
                 is_special_message = true;
             }
@@ -280,6 +335,39 @@ async fn sign(wallet_id: String, msg: String) -> Result<String, String> {
             }
         });
     }
+
+    // handle for add and remove signer
+    if let Some(new_signer) = pending_add_signer {
+        if let Some(mut wallet) = WALLETS.with(|w| w.borrow().get(&wallet_id).cloned()) {
+            if wallet.add_signer(new_signer, &wallet_id).await.is_ok() {
+                WALLETS.with(|w| w.borrow_mut().insert(wallet_id.clone(), wallet));
+                PRINCIPAL_WALLETS_MAP.with(|map| {
+                    map.borrow_mut()
+                        .entry(new_signer)
+                        .or_default()
+                        .insert(wallet_id.clone());
+                });
+            }
+        }
+    }
+    if let Some(signer_to_remove) = pending_remove_signer {
+        if let Some(mut wallet) = WALLETS.with(|w| w.borrow().get(&wallet_id).cloned()) {
+            if wallet
+                .remove_signer(signer_to_remove, &wallet_id)
+                .await
+                .is_ok()
+            {
+                WALLETS.with(|w| w.borrow_mut().insert(wallet_id.clone(), wallet));
+                PRINCIPAL_WALLETS_MAP.with(|map| {
+                    if let Some(wallet_list) = map.borrow_mut().get_mut(&signer_to_remove) {
+                        wallet_list.retain(|id| id != &wallet_id);
+                    }
+                });
+            }
+        }
+    }
+
+    // handle for transfer
     if let Some((wallet_clone, args)) = pending_transfer {
         wallet_clone
             .transfer(args)
@@ -291,12 +379,16 @@ async fn sign(wallet_id: String, msg: String) -> Result<String, String> {
         false => hex::encode(sign_message(wallet_id.clone(), msg.clone(), key_id).await?),
     };
 
-    let _ = WALLETS.with(|wallets| {
-        wallets
-            .borrow_mut()
-            .get_mut(&wallet_id)
-            .ok_or(WALLET_NOT_FOUND_ERROR.to_string())?
-            .remove_message_and_metadata(msg.clone(), caller())
+    let mut wallet = WALLETS
+        .with(|wallets| wallets.borrow().get(&wallet_id).cloned())
+        .ok_or_else(|| WALLET_NOT_FOUND_ERROR.to_string())?;
+
+    let _ = wallet
+        .remove_message_and_metadata(msg.clone(), &wallet_id)
+        .await;
+
+    WALLETS.with(|wallets| {
+        wallets.borrow_mut().insert(wallet_id, wallet);
     });
 
     Ok(signature)
@@ -334,21 +426,15 @@ async fn verify_signature(
 /// # Returns
 ///
 /// * `Vec<Vec<u8>>` - A list of messages that can be signed.
-#[query]
-fn get_messages_to_sign(wallet_id: String) -> Result<Vec<String>, String> {
-    WALLETS.with(|wallets| {
-        wallets
-            .borrow()
-            .get(&wallet_id)
-            .ok_or(WALLET_NOT_FOUND_ERROR.to_string())
-            .map(|wallet| {
-                wallet
-                    .get_messages_to_sign()
-                    .into_iter()
-                    .map(hex::encode)
-                    .collect()
-            })
-    })
+#[update]
+async fn get_messages_to_sign(wallet_id: String) -> Result<Vec<String>, String> {
+    let wallet = WALLETS
+        .with(|wallets| wallets.borrow().get(&wallet_id).cloned())
+        .ok_or_else(|| WALLET_NOT_FOUND_ERROR.to_string())?;
+
+    let messages = wallet.get_messages_to_sign(&wallet_id).await?;
+
+    Ok(messages.into_iter().map(hex::encode).collect())
 }
 
 /// Retrieves all messages that have been proposed for a given wallet.
@@ -360,21 +446,15 @@ fn get_messages_to_sign(wallet_id: String) -> Result<Vec<String>, String> {
 /// # Returns
 ///
 /// * `Vec<Vec<u8>>` - A list of messages that have been proposed.
-#[query]
-fn get_proposed_messages(wallet_id: String) -> Result<Vec<String>, String> {
-    WALLETS.with(|wallets| {
-        wallets
-            .borrow()
-            .get(&wallet_id)
-            .ok_or(WALLET_NOT_FOUND_ERROR.to_string())
-            .map(|wallet| {
-                wallet
-                    .get_proposed_messages()
-                    .into_iter()
-                    .map(hex::encode)
-                    .collect()
-            })
-    })
+#[update]
+async fn get_proposed_messages(wallet_id: String) -> Result<Vec<String>, String> {
+    let wallet = WALLETS
+        .with(|wallets| wallets.borrow().get(&wallet_id).cloned())
+        .ok_or_else(|| WALLET_NOT_FOUND_ERROR.to_string())?;
+
+    let messages = wallet.get_proposed_messages(&wallet_id).await?;
+
+    Ok(messages.into_iter().map(hex::encode).collect())
 }
 
 /// Retrieves all messages that have been proposed along with their signers for a given wallet.
@@ -385,22 +465,23 @@ fn get_proposed_messages(wallet_id: String) -> Result<Vec<String>, String> {
 ///
 /// # Returns
 ///
-/// * `Vec<(Vec<u8>, Vec<Principal>)>` - A list of tuples containing messages and their signers.
-#[query]
-fn get_messages_with_signers(wallet_id: String) -> Result<Vec<(String, Vec<Principal>)>, String> {
-    WALLETS.with(|wallets| {
-        wallets
-            .borrow()
-            .get(&wallet_id)
-            .ok_or(WALLET_NOT_FOUND_ERROR.to_string())
-            .map(|wallet| {
-                wallet
-                    .get_messages_with_signers()
-                    .into_iter()
-                    .map(|(msg, signers)| (hex::encode(msg), signers))
-                    .collect()
-            })
-    })
+/// * `Vec<(Vec<u8>, Vec<String>)>` - A list of tuples containing messages and their signers (hex-string).
+#[update]
+async fn get_messages_with_signers(
+    wallet_id: String,
+) -> Result<Vec<(String, Vec<String>)>, String> {
+    let wallet = WALLETS
+        .with(|wallets| wallets.borrow().get(&wallet_id).cloned())
+        .ok_or_else(|| WALLET_NOT_FOUND_ERROR.to_string())?;
+
+    let messages_with_signers = wallet.get_messages_with_signers(&wallet_id).await?;
+
+    let result = messages_with_signers
+        .into_iter()
+        .map(|(msg, signers)| (hex::encode(msg), signers))
+        .collect();
+
+    Ok(result)
 }
 
 /// Proposes adding a new signer to the wallet.
@@ -414,10 +495,10 @@ fn get_messages_with_signers(wallet_id: String) -> Result<Vec<(String, Vec<Princ
 ///
 /// * `Result<(), String>` - Result indicating success or an error message.
 #[update]
-fn add_signer(wallet_id: String, new_signer: Principal) -> Result<String, String> {
+async fn add_signer(wallet_id: String, new_signer: Principal) -> Result<String, String> {
     debug_println_caller("add_signer");
     let special_message = hex::encode(format!("ADD_SIGNER::{new_signer}"));
-    let _ = propose(wallet_id, special_message.clone());
+    let _ = propose(wallet_id, special_message.clone()).await?;
     Ok(special_message)
 }
 
@@ -432,9 +513,10 @@ fn add_signer(wallet_id: String, new_signer: Principal) -> Result<String, String
 ///
 /// * `Result<(), String>` - Result indicating success or an error message.
 #[update]
-fn remove_signer(wallet_id: String, signer_to_remove: Principal) -> Result<String, String> {
+async fn remove_signer(wallet_id: String, signer_to_remove: Principal) -> Result<String, String> {
+    debug_println_caller("remove_signer");
     let special_message = hex::encode(format!("REMOVE_SIGNER::{signer_to_remove}"));
-    let _ = propose(wallet_id, special_message.clone());
+    let _ = propose(wallet_id, special_message.clone()).await?;
     Ok(special_message)
 }
 
@@ -449,16 +531,20 @@ fn remove_signer(wallet_id: String, signer_to_remove: Principal) -> Result<Strin
 ///
 /// * `Result<String, String>` - Result indicating success or an error message.
 #[update]
-fn set_threshold(wallet_id: String, new_threshold: u8) -> Result<String, String> {
+async fn set_threshold(wallet_id: String, new_threshold: u8) -> Result<String, String> {
     let special_message = hex::encode(format!("SET_THRESHOLD::{new_threshold}"));
-    let _ = propose(wallet_id, special_message.clone());
+    let _ = propose(wallet_id, special_message.clone()).await?;
     Ok(special_message)
 }
 
 #[update]
-fn transfer(wallet_id: String, amount: u64, to_principal: Principal) -> Result<String, String> {
+async fn transfer(
+    wallet_id: String,
+    amount: u64,
+    to_principal: Principal,
+) -> Result<String, String> {
     let special_message = hex::encode(format!("TRANSFER::{amount}::{to_principal}"));
-    let _ = propose(wallet_id, special_message.clone());
+    let _ = propose(wallet_id, special_message.clone()).await?;
     Ok(special_message)
 }
 
@@ -470,9 +556,9 @@ fn transfer(wallet_id: String, amount: u64, to_principal: Principal) -> Result<S
 ///
 /// # Returns
 ///
-/// * `Vec<String>` - A list of wallet IDs associated with the principal.
+/// * `HashSet<String>` - A list of wallet IDs associated with the principal.
 #[query]
-fn get_wallets_for_principal(principal: Principal) -> Vec<String> {
+fn get_wallets_for_principal(principal: Principal) -> HashSet<String> {
     PRINCIPAL_WALLETS_MAP.with(|map| map.borrow().get(&principal).cloned().unwrap_or_default())
 }
 
@@ -484,15 +570,20 @@ fn get_wallets_for_principal(principal: Principal) -> Vec<String> {
 ///
 /// Returns `Result<(), String>` indicating success or the type of failure.
 #[update]
-fn add_metadata(wallet_id: String, msg: String, metadata: String) -> Result<(), String> {
+async fn add_metadata(wallet_id: String, msg: String, metadata: String) -> Result<(), String> {
     let msg = hex::decode(msg).map_err(|_| "InvalidMessage".to_string())?;
+
+    let mut wallet = WALLETS
+        .with(|wallets| wallets.borrow().get(&wallet_id).cloned())
+        .ok_or_else(|| WALLET_NOT_FOUND_ERROR.to_string())?;
+
+    wallet.add_metadata(msg, metadata, &wallet_id).await?;
+
     WALLETS.with(|wallets| {
-        wallets
-            .borrow_mut()
-            .get_mut(&wallet_id)
-            .ok_or(WALLET_NOT_FOUND_ERROR.to_string())?
-            .add_metadata(msg, metadata, caller())
-    })
+        wallets.borrow_mut().insert(wallet_id, wallet);
+    });
+
+    Ok(())
 }
 
 /// Get the metadata associated with a message in the wallet.
@@ -500,18 +591,20 @@ fn add_metadata(wallet_id: String, msg: String, metadata: String) -> Result<(), 
 /// * `message` - The message as a `Vec<u8>`.
 ///
 /// Returns `Option<&String>` containing the metadata if it exists.
-#[query]
-fn get_metadata(wallet_id: String, msg: String) -> Result<String, String> {
+#[update]
+async fn get_metadata(wallet_id: String, msg: String) -> Result<String, String> {
     let msg = hex::decode(msg).map_err(|_| "InvalidMessage".to_string())?;
-    WALLETS.with(|wallets| {
-        wallets
-            .borrow()
-            .get(&wallet_id)
-            .ok_or(WALLET_NOT_FOUND_ERROR.to_string())?
-            .get_metadata(msg, caller())
-            .cloned()
-            .ok_or(METADATA_NOT_FOUND.to_string())
-    })
+
+    let wallet = WALLETS
+        .with(|wallets| wallets.borrow().get(&wallet_id).cloned())
+        .ok_or_else(|| WALLET_NOT_FOUND_ERROR.to_string())?;
+
+    let result = wallet
+        .get_metadata(msg, &wallet_id)
+        .await
+        .ok_or_else(|| METADATA_NOT_FOUND.to_string())?;
+
+    Ok(result.clone())
 }
 
 /// Proposes a message and adds metadata in one call.
@@ -526,9 +619,13 @@ fn get_metadata(wallet_id: String, msg: String) -> Result<String, String> {
 ///
 /// * `Result<(), String>` - Result indicating success or an error message.
 #[update]
-fn propose_with_metadata(wallet_id: String, msg: String, metadata: String) -> Result<(), String> {
-    propose(wallet_id.clone(), msg.clone())?;
-    add_metadata(wallet_id, msg, metadata)
+async fn propose_with_metadata(
+    wallet_id: String,
+    msg: String,
+    metadata: String,
+) -> Result<(), String> {
+    propose(wallet_id.clone(), msg.clone()).await?;
+    add_metadata(wallet_id, msg, metadata).await
 }
 
 fn debug_println_caller(method_name: &str) {

--- a/src/q3x_backend/src/privacy.rs
+++ b/src/q3x_backend/src/privacy.rs
@@ -1,0 +1,508 @@
+use std::collections::{HashMap, HashSet};
+
+use candid::Principal;
+use ic_vetkeys::{DerivedPublicKey, IbeCiphertext, IbeIdentity, IbeSeed, VetKey};
+
+use crate::{
+    vetkey::{derive_seed_simple, get_wallet_decryption_key, get_wallet_public_key},
+    wallet::Wallet,
+};
+
+const ENCODING_ERROR: &str = "EncodingError";
+const SEED_ERROR: &str = "SeedError";
+const CIPHERTEXT_ERROR: &str = "CiphertextError";
+const DECODE_ERROR: &str = "DecodeError";
+
+// ENCRYPTION
+
+/// Encrypts a single principal using IBE with the provided public key.
+///
+/// Encodes the principal, derives a deterministic seed, and encrypts using
+/// Identity-Based Encryption with wallet_id as the identity.
+///
+/// # Arguments
+///
+/// * `signer` - The principal to encrypt.
+/// * `wallet_id` - The wallet identifier used as IBE identity.
+/// * `ibe_public_key` - The IBE public key for encryption.
+///
+/// # Returns
+///
+/// * `Result<String, String>` - Encrypted principal as hex string or error message.
+async fn encrypt_single_principal_with_key(
+    signer: Principal,
+    wallet_id: &str,
+    ibe_public_key: &DerivedPublicKey,
+) -> Result<String, String> {
+    // 1. Encode the principal to bytes
+    let principal_bytes = candid::encode_args((signer,)).map_err(|_| ENCODING_ERROR)?;
+
+    // 2. Get bytes from wallet-id and principal
+    let seed_bytes = derive_seed_simple(wallet_id, signer.as_slice());
+
+    // 3. Create the IBE seed
+    let seed = IbeSeed::from_bytes(&seed_bytes).map_err(|_| SEED_ERROR)?;
+
+    // 4. Encrypt using IBE
+    let ibe_ciphertext = IbeCiphertext::encrypt(
+        ibe_public_key,
+        &IbeIdentity::from_bytes(wallet_id.as_bytes()),
+        &principal_bytes,
+        &seed,
+    );
+
+    // 5. Return the encrypted data as a hex string
+    Ok(hex::encode(ibe_ciphertext.serialize()))
+}
+
+
+/// Encrypts multiple principals using VetKD-derived keys.
+///
+/// Retrieves the wallet's IBE public key once and encrypts each principal
+/// individually, returning a vector of hex-encoded encrypted strings.
+///
+/// # Arguments
+///
+/// * `signers` - Array of principals to encrypt.
+/// * `wallet_id` - The wallet identifier for key derivation.
+///
+/// # Returns
+///
+/// * `Result<Vec<String>, String>` - Vector of encrypted principals as hex strings or error message.
+pub async fn encrypt_principals_with_vetkeys(
+    signers: &[Principal],
+    wallet_id: &str,
+) -> Result<Vec<String>, String> {
+    let mut encrypted_signers = Vec::new();
+
+    // Get the IBE public key
+    let ibe_public_key = get_wallet_public_key(wallet_id).await?;
+
+    // Encrypt each signer individually
+    for signer in signers {
+        let encrypted_hex =
+            encrypt_single_principal_with_key(*signer, wallet_id, &ibe_public_key).await?;
+        encrypted_signers.push(encrypted_hex);
+    }
+
+    Ok(encrypted_signers)
+}
+
+
+/// Encrypts a message using IBE with the provided public key.
+///
+/// Derives a deterministic seed from wallet_id and message, then encrypts
+/// using Identity-Based Encryption with wallet_id as the identity.
+///
+/// # Arguments
+///
+/// * `message` - The message bytes to encrypt.
+/// * `wallet_id` - The wallet identifier used as IBE identity.
+/// * `ibe_public_key` - The IBE public key for encryption.
+///
+/// # Returns
+///
+/// * `Result<Vec<u8>, String>` - Encrypted message bytes or error message.
+async fn encrypt_message_with_key(
+    message: &Vec<u8>,
+    wallet_id: &str,
+    ibe_public_key: &DerivedPublicKey,
+) -> Result<Vec<u8>, String> {
+    // 1. Get seed bytes from wallet-id and message
+    let seed_bytes = derive_seed_simple(wallet_id, &message);
+
+    // 2. Create the IBE seed
+    let seed = IbeSeed::from_bytes(&seed_bytes).map_err(|_| SEED_ERROR)?;
+
+    // 3. Encrypt using IBE
+    let ibe_ciphertext = IbeCiphertext::encrypt(
+        ibe_public_key,
+        &IbeIdentity::from_bytes(wallet_id.as_bytes()),
+        &message,
+        &seed,
+    );
+
+    // 4. Return the encrypted data
+    Ok(ibe_ciphertext.serialize())
+}
+
+
+/// Encrypts a message using VetKD-derived keys.
+///
+/// Retrieves the wallet's IBE public key and encrypts the message,
+/// returning the encrypted bytes.
+///
+/// # Arguments
+///
+/// * `message` - The message bytes to encrypt.
+/// * `wallet_id` - The wallet identifier for key derivation.
+///
+/// # Returns
+///
+/// * `Result<Vec<u8>, String>` - Encrypted message bytes or error message.
+pub async fn encrypt_message_with_vetkeys(
+    message: &Vec<u8>,
+    wallet_id: &str,
+) -> Result<Vec<u8>, String> {
+    // Get the IBE public key using helper
+    let ibe_public_key = get_wallet_public_key(wallet_id).await?;
+
+    encrypt_message_with_key(message, wallet_id, &ibe_public_key).await
+}
+
+
+/// Encrypts metadata using VetKD-derived keys.
+///
+/// Retrieves the wallet's IBE public key, encodes the metadata string,
+/// and encrypts it using Identity-Based Encryption.
+///
+/// # Arguments
+///
+/// * `metadata` - The metadata string to encrypt.
+/// * `wallet_id` - The wallet identifier for key derivation.
+///
+/// # Returns
+///
+/// * `Result<String, String>` - Encrypted metadata as hex string or error message.
+pub async fn encrypt_metadata_with_vetkeys(
+    metadata: String,
+    wallet_id: &str,
+) -> Result<String, String> {
+    // Get the IBE public key
+    let ibe_public_key = get_wallet_public_key(wallet_id).await?;
+
+    // 1. Encode the metadata to bytes
+    let metadata_bytes = candid::encode_args((metadata,)).map_err(|_| ENCODING_ERROR)?;
+
+    // 2. Get seed bytes from wallet-id and metadata
+    let seed_bytes = derive_seed_simple(wallet_id, &metadata_bytes);
+
+    // 3. Create the IBE seed
+    let seed = IbeSeed::from_bytes(&seed_bytes).map_err(|_| SEED_ERROR)?;
+
+    // 4. Encrypt using IBE
+    let ibe_ciphertext = IbeCiphertext::encrypt(
+        &ibe_public_key,
+        &IbeIdentity::from_bytes(wallet_id.as_bytes()),
+        &metadata_bytes,
+        &seed,
+    );
+
+    // 5. Return the encrypted data as a hex string
+    Ok(hex::encode(ibe_ciphertext.serialize()))
+}
+
+
+/// Encrypts both a principal and message using VetKD-derived keys.
+///
+/// Retrieves the wallet's IBE public key once and encrypts both the principal
+/// and message, optimizing performance by reusing the same key.
+///
+/// # Arguments
+///
+/// * `signer` - The principal to encrypt.
+/// * `message` - The message bytes to encrypt.
+/// * `wallet_id` - The wallet identifier for key derivation.
+///
+/// # Returns
+///
+/// * `Result<(String, Vec<u8>), String>` - Tuple of (encrypted principal as hex, encrypted message bytes) or error message.
+pub async fn encrypt_principal_and_message_with_vetkeys(
+    signer: Principal,
+    message: &Vec<u8>,
+    wallet_id: &str,
+) -> Result<(String, Vec<u8>), String> {
+    // Get the IBE public key once
+    let ibe_public_key = get_wallet_public_key(wallet_id).await?;
+
+    let encrypted_principal =
+        encrypt_single_principal_with_key(signer, wallet_id, &ibe_public_key).await?;
+
+    let encrypted_message = encrypt_message_with_key(message, wallet_id, &ibe_public_key).await?;
+
+    Ok((encrypted_principal, encrypted_message))
+}
+
+// DECRYPTION
+/// Decrypts a single principal from hex-encoded encrypted data.
+///
+/// Decodes the hex string, deserializes the IBE ciphertext, decrypts using
+/// the provided key, and decodes back to a Principal.
+///
+/// # Arguments
+///
+/// * `encrypted_hex` - The hex-encoded encrypted principal data.
+/// * `ibe_decryption_key` - The IBE decryption key.
+///
+/// # Returns
+///
+/// * `Result<Principal, String>` - The decrypted principal or error message.
+async fn decrypt_single_principal_hex(
+    encrypted_hex: &str,
+    ibe_decryption_key: &VetKey,
+) -> Result<Principal, String> {
+    // 1. Decode hex to bytes
+    let encrypted_data = hex::decode(encrypted_hex).map_err(|_| CIPHERTEXT_ERROR)?;
+
+    // 2. Deserialize the ciphertext
+    let ibe_ciphertext =
+        IbeCiphertext::deserialize(&encrypted_data).map_err(|_| CIPHERTEXT_ERROR)?;
+
+    // 3. Decrypt the ciphertext
+    let decrypted_bytes = ibe_ciphertext
+        .decrypt(ibe_decryption_key)
+        .map_err(|_| CIPHERTEXT_ERROR)?;
+
+    // 4. Decode back to principal
+    let (principal,): (Principal,) =
+        candid::decode_args(&decrypted_bytes).map_err(|_| DECODE_ERROR)?;
+
+    Ok(principal)
+}
+
+
+/// Decrypts multiple principals from a list of hex-encoded encrypted data.
+///
+/// Retrieves the IBE decryption key for the specified wallet and decrypts
+/// each hex-encoded principal in the provided list.
+///
+/// # Arguments
+///
+/// * `encrypted_hex_list` - A slice of hex-encoded encrypted principal data.
+/// * `wallet_id` - The wallet identifier used to retrieve the decryption key.
+///
+/// # Returns
+///
+/// * `Result<Vec<Principal>, String>` - Vector of decrypted principals or error message.
+pub async fn decrypt_principals_with_vetkeys(
+    encrypted_hex_list: &[String],
+    wallet_id: &str,
+) -> Result<Vec<Principal>, String> {
+    // Get the IBE decryption key using helper
+    let ibe_decryption_key = get_wallet_decryption_key(wallet_id).await?;
+
+    // Decrypt each principal
+    let mut decrypted_principals = Vec::new();
+    for encrypted_hex in encrypted_hex_list {
+        let principal = decrypt_single_principal_hex(encrypted_hex, &ibe_decryption_key).await?;
+        decrypted_principals.push(principal);
+    }
+
+    Ok(decrypted_principals)
+}
+
+/// Decrypts a single message from hex-encoded encrypted data.
+///
+/// Decodes the hex string, deserializes the IBE ciphertext, and decrypts using
+/// the provided key to return the original message bytes.
+///
+/// # Arguments
+///
+/// * `encrypted_hex` - The hex-encoded encrypted message data.
+/// * `ibe_decryption_key` - The IBE decryption key.
+///
+/// # Returns
+///
+/// * `Result<Vec<u8>, String>` - The decrypted message bytes or error message.
+async fn decrypt_single_message_hex(
+    encrypted_hex: &str,
+    ibe_decryption_key: &VetKey,
+) -> Result<Vec<u8>, String> {
+    // 1. Decode hex to bytes
+    let encrypted_data = hex::decode(encrypted_hex).map_err(|_| CIPHERTEXT_ERROR)?;
+
+    // 2. Deserialize the ciphertext
+    let ibe_ciphertext =
+        IbeCiphertext::deserialize(&encrypted_data).map_err(|_| CIPHERTEXT_ERROR)?;
+
+    // 3. Decrypt the ciphertext
+    let decrypted_bytes = ibe_ciphertext
+        .decrypt(ibe_decryption_key)
+        .map_err(|_| CIPHERTEXT_ERROR)?;
+
+    Ok(decrypted_bytes)
+}
+
+/// Decrypts a message using wallet-specific VetKeys.
+///
+/// Retrieves the IBE decryption key for the specified wallet and decrypts
+/// the hex-encoded message data.
+///
+/// # Arguments
+///
+/// * `encrypted_hex` - The hex-encoded encrypted message data.
+/// * `wallet_id` - The wallet identifier used to retrieve the decryption key.
+///
+/// # Returns
+///
+/// * `Result<Vec<u8>, String>` - The decrypted message bytes or error message.
+pub async fn decrypt_message_with_vetkeys(
+    encrypted_hex: &str,
+    wallet_id: &str,
+) -> Result<Vec<u8>, String> {
+    let ibe_decryption_key = get_wallet_decryption_key(wallet_id).await?;
+    decrypt_single_message_hex(encrypted_hex, &ibe_decryption_key).await
+}
+
+/// Decrypts multiple messages from a list of hex-encoded encrypted data.
+///
+/// Retrieves the IBE decryption key for the specified wallet and decrypts
+/// each hex-encoded message in the provided list.
+///
+/// # Arguments
+///
+/// * `encrypted_hex_list` - A slice of hex-encoded encrypted message data.
+/// * `wallet_id` - The wallet identifier used to retrieve the decryption key.
+///
+/// # Returns
+///
+/// * `Result<Vec<Vec<u8>>, String>` - Vector of decrypted message bytes or error message.
+pub async fn decrypt_messages_with_vetkeys(
+    encrypted_hex_list: &[String],
+    wallet_id: &str,
+) -> Result<Vec<Vec<u8>>, String> {
+    let ibe_decryption_key = get_wallet_decryption_key(wallet_id).await?;
+
+    let mut decrypted_messages = Vec::new();
+    for encrypted_hex in encrypted_hex_list {
+        let decrypted_msg = decrypt_single_message_hex(encrypted_hex, &ibe_decryption_key).await?;
+        decrypted_messages.push(decrypted_msg);
+    }
+
+    Ok(decrypted_messages)
+}
+
+/// Decrypts a single metadata string from hex-encoded encrypted data.
+///
+/// Decodes the hex string, deserializes the IBE ciphertext, decrypts using
+/// the provided key, and decodes back to a metadata string.
+///
+/// # Arguments
+///
+/// * `encrypted_hex` - The hex-encoded encrypted metadata data.
+/// * `ibe_decryption_key` - The IBE decryption key.
+///
+/// # Returns
+///
+/// * `Result<String, String>` - The decrypted metadata string or error message.
+async fn decrypt_single_metadata_hex(
+    encrypted_hex: &str,
+    ibe_decryption_key: &VetKey,
+) -> Result<String, String> {
+    // 1. Decode hex to bytes
+    let encrypted_data = hex::decode(encrypted_hex).map_err(|_| CIPHERTEXT_ERROR)?;
+
+    // 2. Deserialize the ciphertext
+    let ibe_ciphertext =
+        IbeCiphertext::deserialize(&encrypted_data).map_err(|_| CIPHERTEXT_ERROR)?;
+
+    // 3. Decrypt the ciphertext
+    let decrypted_bytes = ibe_ciphertext
+        .decrypt(ibe_decryption_key)
+        .map_err(|_| CIPHERTEXT_ERROR)?;
+
+    // 4. Decode back to metadata
+    let (metadata,): (String,) = candid::decode_args(&decrypted_bytes).map_err(|_| DECODE_ERROR)?;
+
+    Ok(metadata)
+}
+
+/// Decrypts metadata using wallet-specific VetKeys.
+///
+/// Retrieves the IBE decryption key for the specified wallet and decrypts
+/// the hex-encoded metadata data.
+///
+/// # Arguments
+///
+/// * `encrypted_hex` - The hex-encoded encrypted metadata data.
+/// * `wallet_id` - The wallet identifier used to retrieve the decryption key.
+///
+/// # Returns
+///
+/// * `Result<String, String>` - The decrypted metadata string or error message.
+pub async fn decrypt_metadata_with_vetkeys(
+    encrypted_hex: &str,
+    wallet_id: &str,
+) -> Result<String, String> {
+    let ibe_decryption_key = get_wallet_decryption_key(wallet_id).await?;
+    decrypt_single_metadata_hex(encrypted_hex, &ibe_decryption_key).await
+}
+
+
+/// Decrypts complete wallet data including signers, message queue, and metadata.
+///
+/// Retrieves the IBE decryption key for the specified wallet and decrypts all
+/// encrypted components to reconstruct the wallet with decrypted data.
+///
+/// # Arguments
+///
+/// * `encrypted_signers` - Vector of hex-encoded encrypted signer principals.
+/// * `threshold` - The signing threshold for the wallet.
+/// * `encrypted_message_queue` - Vector of tuples containing encrypted message keys and their associated encrypted signers.
+/// * `encrypted_metadata` - HashMap mapping encrypted message keys to encrypted metadata values.
+/// * `wallet_id` - The wallet identifier used to retrieve the decryption key.
+///
+/// # Returns
+///
+/// * `Result<Wallet, String>` - The reconstructed wallet with decrypted data or error message.
+pub async fn decrypt_wallet_data(
+    encrypted_signers: &Vec<String>,
+    threshold: &u8,
+    encrypted_message_queue: &Vec<(Vec<u8>, Vec<String>)>,
+    encrypted_metadata: &HashMap<Vec<u8>, String>,
+    wallet_id: &str,
+) -> Result<Wallet, String> {
+    // 1. Get decryption key
+    let ibe_decryption_key = get_wallet_decryption_key(wallet_id).await?;
+
+    // 2. Decrypt signers + create signer mapping
+    let mut decrypted_signers = HashSet::new();
+    let mut signer_mapping = HashMap::new(); // encrypted_string -> Principal
+
+    for encrypted_signer in encrypted_signers {
+        let principal = decrypt_single_principal_hex(encrypted_signer, &ibe_decryption_key).await?;
+        decrypted_signers.insert(principal.to_text());
+        signer_mapping.insert(encrypted_signer.clone(), principal.to_text());
+    }
+
+    // 3. Decrypt message_queue + create message mapping
+    let mut decrypted_message_queue = HashMap::new();
+    let mut message_mapping = HashMap::new(); // encrypted_bytes -> decrypted_bytes
+
+    for (encrypted_msg_key, encrypted_signers_vec) in encrypted_message_queue {
+        // Decrypt message key
+        let decrypted_msg =
+            decrypt_single_message_hex(&hex::encode(encrypted_msg_key), &ibe_decryption_key)
+                .await?;
+
+        message_mapping.insert(encrypted_msg_key.clone(), decrypted_msg.clone());
+
+        // Map signers using signer_mapping
+        let mut mapped_principals = Vec::new();
+        for encrypted_signer in encrypted_signers_vec {
+            if let Some(principal) = signer_mapping.get(encrypted_signer) {
+                mapped_principals.push(principal.clone());
+            }
+        }
+
+        decrypted_message_queue.insert(decrypted_msg, mapped_principals);
+    }
+
+    // 4. Decrypt metadata - using message_mapping
+    let mut decrypted_metadata = HashMap::new();
+    for (encrypted_msg_key, encrypted_metadata_value) in encrypted_metadata {
+        if let Some(decrypted_msg) = message_mapping.get(encrypted_msg_key) {
+            // Only decrypt metadata value
+            let decrypted_meta =
+                decrypt_single_metadata_hex(encrypted_metadata_value, &ibe_decryption_key).await?;
+            decrypted_metadata.insert(decrypted_msg.clone(), decrypted_meta);
+        }
+    }
+
+    Ok(Wallet::new_with_data(
+        decrypted_signers,
+        *threshold,
+        decrypted_message_queue,
+        decrypted_metadata,
+    ))
+}

--- a/src/q3x_backend/src/vetkey.rs
+++ b/src/q3x_backend/src/vetkey.rs
@@ -1,0 +1,246 @@
+use std::cell::RefCell;
+
+use candid::CandidType;
+use ic_cdk::management_canister::{VetKDCurve, VetKDDeriveKeyArgs, VetKDKeyId, VetKDPublicKeyArgs};
+use ic_vetkeys::{
+    DerivedPublicKey, EncryptedVetKey, TransportSecretKey,
+    VetKey,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(CandidType, Serialize, Deserialize, Clone)]
+pub struct KeyResponse {
+    pub key_hex: String,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+pub type VetKeyResult<T> = Result<T, ErrorResponse>;
+
+
+const PUBLIC_KEY_ERROR: &str = "PublicKeyError";
+const TRANSPORT_KEY_ERROR: &str = "TransportKeyError";
+const DERIVE_KEY_ERROR: &str = "DeriveKeyError";
+const VETKEY_ERROR: &str = "VetKeyError";
+
+thread_local! {
+    static VETKEY_ID: RefCell<VetKDKeyId> = RefCell::new(VetKDKeyId {
+        curve: VetKDCurve::Bls12_381_G2,
+        name: "dfx_test_key".to_string(),
+    });
+}
+
+/// Sets the VetKD key ID (called from init)
+///
+/// Configures the VetKD key identifier based on the deployment environment.
+/// This should be called once during canister initialization to set the
+/// appropriate key for the target environment.
+///
+/// # Arguments
+///
+/// * `env` - Environment string ("production", "test", or other for local development).
+///
+/// # Behavior
+///
+/// Updates the thread-local VETKEY_ID with environment-specific key configuration:
+/// - "production" -> "key_1"
+/// - "test" -> "test_key_1"  
+/// - other -> "dfx_test_key" (for local development)
+pub fn set_vetkey_id(env: &str) {
+    let key_id = VetKDKeyId {
+        curve: VetKDCurve::Bls12_381_G2,
+        name: match env {
+            "production" => "key_1",
+            "test" => "test_key_1", 
+            _ => "dfx_test_key",
+        }.to_string(),
+    };
+    
+    VETKEY_ID.with(|id| {
+        *id.borrow_mut() = key_id;
+    });
+}
+
+/// Gets the current VetKD key ID
+///
+/// Retrieves the currently configured VetKD key identifier from thread-local storage.
+/// This key ID is used for all VetKD operations within the canister.
+///
+/// # Returns
+///
+/// * `VetKDKeyId` - The current VetKD key identifier with curve and name configuration.
+fn get_vetkey_id() -> VetKDKeyId {
+    VETKEY_ID.with(|id| id.borrow().clone())
+}
+
+/// Derives a 32-byte seed by combining wallet ID and data for cryptographic operations.
+///
+/// Creates a deterministic seed by concatenating wallet ID and data, then normalizing
+/// to exactly 32 bytes (padding with zeros or truncating as needed).
+///
+/// # Arguments
+///
+/// * `wallet_id` - The wallet's unique identifier string.
+/// * `data` - Additional data bytes to include in the seed derivation.
+///
+/// # Returns
+///
+/// * `Vec<u8>` - A 32-byte seed vector suitable for cryptographic operations.
+pub fn derive_seed_simple(wallet_id: &str, data: &[u8]) -> Vec<u8> {
+    let mut seed = Vec::new();
+    seed.extend_from_slice(wallet_id.as_bytes());
+    seed.extend_from_slice(data);
+
+    if seed.len() < 32 {
+        seed.resize(32, 0);
+    } else if seed.len() > 32 {
+        seed.truncate(32);
+    }
+
+    seed
+}
+
+/// Retrieves the VetKD public key for a given context.
+///
+/// Requests a VetKD public key from the IC management canister for encryption
+/// operations, returned as a hexadecimal string.
+///
+/// # Arguments
+///
+/// * `context` - Context bytes for key derivation (typically wallet-specific data).
+///
+/// # Returns
+///
+/// * `VetKeyResult<KeyResponse>` - Public key in hex format or error response.
+pub async fn get_verification_public_key(context: &[u8]) -> VetKeyResult<KeyResponse> {
+    let request = VetKDPublicKeyArgs {
+        canister_id: None,
+        context: context.to_vec(),
+        key_id: get_vetkey_id(),
+    };
+
+    match ic_cdk::management_canister::vetkd_public_key(&request).await {
+        Ok(response) => Ok(KeyResponse {
+            key_hex: hex::encode(response.public_key),
+        }),
+        Err(err) => Err(ErrorResponse {
+            error: format!("Failed to get public key: {:?}", err),
+        }),
+    }
+}
+
+/// Derives an encrypted VetKD key using the provided context and input data.
+///
+/// Requests a derived key from the IC management canister, encrypted with the transport
+/// public key for secure delivery. Used for decryption after transport key decryption.
+///
+/// # Arguments
+///
+/// * `context` - Context bytes for key derivation (typically wallet-specific data).
+/// * `input` - Additional input data for key derivation (e.g., identity bytes).
+/// * `transport_public_key` - Public key used to encrypt the derived key for transport.
+///
+/// # Returns
+///
+/// * `VetKeyResult<KeyResponse>` - Encrypted derived key in hex format or error response.
+pub async fn get_derive_key(
+    context: &[u8],
+    input: Vec<u8>,
+    transport_public_key: Vec<u8>,
+) -> VetKeyResult<KeyResponse> {
+    let request = VetKDDeriveKeyArgs {
+        input,
+        context: context.to_vec(),
+        key_id: get_vetkey_id(),
+        transport_public_key,
+    };
+
+    match ic_cdk::management_canister::vetkd_derive_key(&request).await {
+        Ok(response) => Ok(KeyResponse {
+            key_hex: hex::encode(response.encrypted_key),
+        }),
+        Err(err) => Err(ErrorResponse {
+            error: format!("Failed to derive key: {:?}", err),
+        }),
+    }
+}
+
+/// Retrieves and deserializes the IBE public key for a specific wallet.
+///
+/// Uses wallet_id for key derivation so all wallet members can decrypt shared data
+/// rather than storing separate encrypted versions for each signer.
+///
+/// # Arguments
+///
+/// * `wallet_id` - The wallet's unique identifier for key derivation.
+///
+/// # Returns
+///
+/// * `Result<DerivedPublicKey, String>` - The deserialized IBE public key or error message.
+pub async fn get_wallet_public_key(wallet_id: &str) -> Result<DerivedPublicKey, String> {
+    let wallet_context = format!("wallet_{}", wallet_id).as_bytes().to_vec();
+    let public_key_response = get_verification_public_key(&wallet_context)
+        .await
+        .map_err(|_| PUBLIC_KEY_ERROR)?;
+
+    let decoded_key = hex::decode(public_key_response.key_hex).map_err(|_| PUBLIC_KEY_ERROR)?;
+    let ibe_public_key =
+        DerivedPublicKey::deserialize(&decoded_key).map_err(|_| PUBLIC_KEY_ERROR)?;
+
+    Ok(ibe_public_key)
+}
+
+/// Retrieves the IBE decryption key for a wallet using VetKD key derivation.
+///
+/// Uses wallet_id for key derivation so all wallet members can decrypt shared data.
+/// Performs the complete VetKD flow: transport key creation, public/derived key requests,
+/// and final key decryption/verification.
+///
+/// # Arguments
+///
+/// * `wallet_id` - The wallet's unique identifier for key derivation.
+///
+/// # Returns
+///
+/// * `Result<VetKey, String>` - IBE decryption key or error message.
+pub async fn get_wallet_decryption_key(wallet_id: &str) -> Result<VetKey, String> {
+    // 1. Create transport key
+    let dummy_seed = vec![0; 32];
+    let transport_secret_key =
+        TransportSecretKey::from_seed(dummy_seed).map_err(|_| TRANSPORT_KEY_ERROR)?;
+
+    // 2. Get the public key and derive key
+    let wallet_context = format!("wallet_{}", wallet_id).as_bytes().to_vec();
+    let public_key_response = get_verification_public_key(&wallet_context)
+        .await
+        .map_err(|_| PUBLIC_KEY_ERROR)?;
+
+    // Derive the key using the public key
+    let derive_key_response = get_derive_key(
+        &wallet_context,
+        wallet_id.as_bytes().to_vec(),
+        transport_secret_key.public_key().to_vec(),
+    )
+    .await
+    .map_err(|_| DERIVE_KEY_ERROR)?;
+
+    // 3. Decrypt and verify
+    let ibe_public_key = DerivedPublicKey::deserialize(
+        &hex::decode(public_key_response.key_hex).map_err(|_| PUBLIC_KEY_ERROR)?,
+    )
+    .map_err(|_| PUBLIC_KEY_ERROR)?;
+
+    let encrypted_vetkey = EncryptedVetKey::deserialize(
+        &hex::decode(derive_key_response.key_hex).map_err(|_| DERIVE_KEY_ERROR)?,
+    )
+    .map_err(|_| VETKEY_ERROR)?;
+
+    let ibe_decryption_key = encrypted_vetkey
+        .decrypt_and_verify(&transport_secret_key, &ibe_public_key, wallet_id.as_bytes())
+        .map_err(|_| VETKEY_ERROR)?;
+
+    Ok(ibe_decryption_key)
+}

--- a/src/q3x_backend/src/wallet.rs
+++ b/src/q3x_backend/src/wallet.rs
@@ -1,5 +1,4 @@
 use candid::{CandidType, Principal};
-//use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 
 use ic_ledger_types::{
@@ -8,6 +7,12 @@ use ic_ledger_types::{
 };
 
 use serde::{Deserialize, Serialize};
+
+use crate::privacy::{
+    decrypt_messages_with_vetkeys, decrypt_metadata_with_vetkeys, decrypt_wallet_data,
+    encrypt_metadata_with_vetkeys, encrypt_principal_and_message_with_vetkeys,
+    encrypt_principals_with_vetkeys,
+};
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct TransferArgs {
@@ -21,10 +26,14 @@ pub enum WalletError {
     InvalidSignature,
     /// Error when a message is already queued for signing.
     MsgAlreadyQueued,
+    /// Error when message is sign by same signer again.
+    MsgAlreadySignedBySigner,
     /// Error when a message is not found in the queue.
     MsgNotQueued,
     /// Error when there are not enough signers to meet the threshold.
     NotEnoughSigners,
+    /// Error when encryption fails
+    EncryptionError,
 }
 
 /// A trait defining the behaviors of a MultiSignature Wallet.
@@ -32,17 +41,24 @@ pub trait MultiSignatureWallet {
     /// Add a new signer to the wallet.
     ///
     /// * `signer` - The `Principal` of the signer to add.
-    fn add_signer(&mut self, signer: Principal);
+    /// * `wallet_id` - The ID of the wallet.
+    async fn add_signer(&mut self, signer: Principal, wallet_id: &str) -> Result<(), String>;
+
+    /// Add a new signer to the wallet.
+    ///
+    /// * `signer` - The `Principal - hexString` of the signer to add.
+    fn add_signer_principal_hex(&mut self, signer: String);
 
     /// Remove an existing signer from the wallet.
     ///
     /// * `signer` - The `Principal` of the signer to remove.
-    fn remove_signer(&mut self, signer: Principal);
+    /// * `wallet_id` - The ID of the wallet.
+    async fn remove_signer(&mut self, signer: Principal, wallet_id: &str) -> Result<(), String>;
 
     /// Get a list of all current signers of the wallet.
     ///
     /// Returns a `Vec<Principal>` containing the principals of all signers.
-    fn get_signers(&self) -> Vec<Principal>;
+    fn get_signers(&self) -> Vec<String>;
 
     /// Set the default threshold for signing.
     ///
@@ -60,10 +76,17 @@ pub trait MultiSignatureWallet {
 
     /// Check if a given `Principal` is a signer in the wallet.
     ///
-    /// * `signer` - The `Principal` to check.
+    /// * `wallet_id` - The ID of the wallet.
     ///
     /// Returns `bool` indicating whether the signer is present.
-    fn has_signer(&self, signer: Principal) -> bool;
+    async fn has_signer(&self, wallet_id: &str) -> bool;
+
+    /// Check if a given `Principal - encrypted_data` is a signer in the wallet.
+    ///
+    /// * `encrypted_signer` - The `Principal - encrypted_data` to check.
+    ///
+    /// Returns `bool` indicating whether the signer is present.
+    fn has_encrypted_signer(&self, encrypted_signer: &str) -> bool;
 
     /// Get the current default threshold for signing.
     ///
@@ -74,9 +97,10 @@ pub trait MultiSignatureWallet {
     ///
     /// * `caller` - The `Principal` proposing the message.
     /// * `msg` - The message as a `Vec<u8>`.
+    /// * `wallet_id` - The ID of the wallet.
     ///
     /// Returns `Result<(), WalletError>` indicating success or the type of failure.
-    fn propose_message(&mut self, caller: Principal, msg: Vec<u8>) -> Result<(), WalletError>;
+    async fn propose_message(&mut self, msg: Vec<u8>, wallet_id: &str) -> Result<(), WalletError>;
 
     /// Check if a message can be signed according to the current rules.
     ///
@@ -88,83 +112,132 @@ pub trait MultiSignatureWallet {
     /// Approve a message with a signer's consent.
     ///
     /// * `msg` - The message as a `Vec<u8>`.
-    /// * `signer` - The `Principal` of the signer approving the message.
+    /// * `wallet_id` - The ID of the wallet.
     ///
     /// Returns `Result<u8, WalletError>` indicating the number of approvals or the type of failure.
-    fn approve(&mut self, msg: Vec<u8>, signer: Principal) -> Result<u8, WalletError>;
+    async fn approve(&mut self, msg: Vec<u8>, wallet_id: &str) -> Result<u8, WalletError>;
 
     /// Returns all messages that can be signed.
     ///
+    /// * `wallet_id` - The ID of the wallet.
+    ///
     /// Returns a `Vec<Vec<u8>>` containing the messages that can be signed.
-    fn get_messages_to_sign(&self) -> Vec<Vec<u8>>;
+    async fn get_messages_to_sign(&self, wallet_id: &str) -> Result<Vec<Vec<u8>>, String>;
 
     /// Returns all messages that have been proposed.
     ///
+    /// * `wallet_id` - The ID of the wallet.
+    ///
     /// Returns a `Vec<Vec<u8>>` containing the messages that have been proposed.
-    fn get_proposed_messages(&self) -> Vec<Vec<u8>>;
+    async fn get_proposed_messages(&self, wallet_id: &str) -> Result<Vec<Vec<u8>>, String>;
 
     /// Returns all messages that have been proposed with their signers.
     ///
+    /// * `wallet_id` - The ID of the wallet.
+    ///
     /// Returns a `Vec<(Vec<u8>, Vec<Principal>)>` containing the messages that have been proposed with their signers.
-    fn get_messages_with_signers(&self) -> Vec<(Vec<u8>, Vec<Principal>)>;
+    async fn get_messages_with_signers(
+        &self,
+        wallet_id: &str,
+    ) -> Result<Vec<(Vec<u8>, Vec<String>)>, String>;
+
+    /// Returns all encrypted messages that have been proposed with their signers.
+    ///
+    /// Returns a `Vec<(Vec<u8>, Vec<Principal>)>` containing the messages that have been proposed with their signers.
+    fn get_encrypted_messages_with_signers(&self) -> Vec<(Vec<u8>, Vec<String>)>;
 
     /// Add metadata to a message in the wallet.
     ///
     /// * `message` - The message as a `Vec<u8>`.
     /// * `metadata` - The metadata as a `String`.
-    /// * `caller` - The `Principal` of the caller.
+    /// * `wallet_id` - The ID of the wallet.
     ///
     /// Returns `Result<(), String>` indicating success or the type of failure.
-    fn add_metadata(
+    async fn add_metadata(
         &mut self,
         message: Vec<u8>,
         metadata: String,
-        caller: Principal,
+        wallet_id: &str,
     ) -> Result<(), String>;
 
     /// Get the metadata associated with a message in the wallet.
     ///
     /// * `message` - The message as a `Vec<u8>`.
-    /// * `caller` - The `Principal` of the caller.
+    /// * `wallet_id` - The ID of the wallet.
     ///
     /// Returns `Option<&String>` containing the metadata if it exists.
-    fn get_metadata(&self, message: Vec<u8>, caller: Principal) -> Option<&String>;
+    async fn get_metadata(&self, message: Vec<u8>, wallet_id: &str) -> Option<String>;
+
+    /// Get all the metadata associated with wallet.
+    /// Returns `HashMap<Vec<u8>, String>` containing all the metadata.
+    fn get_all_metadata(&self) -> HashMap<Vec<u8>, String>;
 
     /// Remove a message and its metadata from the wallet.
     ///
     /// * `msg` - The message as a `Vec<u8>`.
-    /// * `caller` - The `Principal` of the caller.
     ///
     /// Returns `Result<(), String>` indicating success or the type of failure.
-    fn remove_message_and_metadata(
+    async fn remove_message_and_metadata(
         &mut self,
         msg: Vec<u8>,
-        caller: Principal,
+        wallet_id: &str,
     ) -> Result<(), String>;
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Default)]
 pub struct Wallet {
-    /// A set of signers for the wallet, represented by their `Principal`.
-    signers: HashSet<Principal>,
+    /// A set of signers for the wallet, represented by their `Principal` hex string.
+    signers: HashSet<String>,
     /// The threshold number of signers required for certain actions.
     threshold: u8,
-    /// A map tracking messages and the list of signers who have already signed them.
-    message_queue: HashMap<Vec<u8>, Vec<Principal>>,
+    /// A map tracking messages and the list of signers (hex string) who have already signed them.
+    message_queue: HashMap<Vec<u8>, Vec<String>>,
     /// A map tracking messages and their metadata.
     metadata: HashMap<Vec<u8>, String>,
 }
 
+impl Wallet {
+    pub fn new_with_data(
+        signers: HashSet<String>,
+        threshold: u8,
+        message_queue: HashMap<Vec<u8>, Vec<String>>,
+        metadata: HashMap<Vec<u8>, String>,
+    ) -> Self {
+        Wallet {
+            signers,
+            threshold,
+            message_queue,
+            metadata,
+        }
+    }
+}
+
 impl MultiSignatureWallet for Wallet {
-    fn add_signer(&mut self, signer: Principal) {
+    async fn add_signer(&mut self, signer: Principal, wallet_id: &str) -> Result<(), String> {
+        let encrypted_array = encrypt_principals_with_vetkeys(&[signer], wallet_id).await?;
+        let encrypted_hex = encrypted_array
+            .into_iter()
+            .next()
+            .ok_or("Failed to encrypt signer")?;
+        self.signers.insert(encrypted_hex);
+        Ok(())
+    }
+
+    fn add_signer_principal_hex(&mut self, signer: String) {
         self.signers.insert(signer);
     }
 
-    fn remove_signer(&mut self, signer: Principal) {
-        self.signers.remove(&signer);
+    async fn remove_signer(&mut self, signer: Principal, wallet_id: &str) -> Result<(), String> {
+        let encrypted_array = encrypt_principals_with_vetkeys(&[signer], wallet_id).await?;
+        let encrypted_hex = encrypted_array
+            .into_iter()
+            .next()
+            .ok_or("Failed to encrypt signer")?;
+        self.signers.remove(&encrypted_hex);
+        Ok(())
     }
 
-    fn get_signers(&self) -> Vec<Principal> {
+    fn get_signers(&self) -> Vec<String> {
         self.signers.iter().cloned().collect()
     }
 
@@ -196,474 +269,606 @@ impl MultiSignatureWallet for Wallet {
             to: AccountIdentifier::new(&args.to_principal, &to_subaccount),
             created_at_time: None,
         };
-        ic_ledger_types::transfer(MAINNET_LEDGER_CANISTER_ID, transfer_args)
+        ic_ledger_types::transfer(MAINNET_LEDGER_CANISTER_ID, &transfer_args)
             .await
             .map_err(|e| format!("failed to call ledger: {e:?}"))?
             .map_err(|e| format!("ledger transfer error {e:?}"))
     }
 
-    fn has_signer(&self, signer: Principal) -> bool {
-        self.signers.contains(&signer)
+    async fn has_signer(&self, wallet_id: &str) -> bool {
+        let signer = ic_cdk::api::msg_caller();
+        if let Ok(encrypted_array) = encrypt_principals_with_vetkeys(&[signer], wallet_id).await {
+            if let Some(encrypted_hex) = encrypted_array.into_iter().next() {
+                return self.signers.contains(&encrypted_hex);
+            }
+        }
+        false
+    }
+
+    fn has_encrypted_signer(&self, encrypted_signer: &str) -> bool {
+        self.signers.contains(encrypted_signer)
     }
 
     fn get_default_threshold(&self) -> u8 {
         self.threshold
     }
 
-    fn propose_message(&mut self, caller: Principal, msg: Vec<u8>) -> Result<(), WalletError> {
-        if !self.signers.contains(&caller) {
+    async fn propose_message(&mut self, msg: Vec<u8>, wallet_id: &str) -> Result<(), WalletError> {
+        let signer = ic_cdk::api::msg_caller();
+        let (encrypted_principal, encrypted_message) =
+            encrypt_principal_and_message_with_vetkeys(signer, &msg, &wallet_id)
+                .await
+                .map_err(|_| WalletError::EncryptionError)?;
+
+        if !self.has_encrypted_signer(&encrypted_principal) {
             return Err(WalletError::InvalidSignature);
         }
 
-        if self.message_queue.contains_key(&msg) {
+        if self.message_queue.contains_key(&encrypted_message) {
             return Err(WalletError::MsgAlreadyQueued);
         }
 
-        self.message_queue.insert(msg.clone(), Vec::new());
+        self.message_queue
+            .insert(encrypted_message.clone(), Vec::new());
 
         Ok(())
     }
 
-    fn can_sign(&self, msg: &Vec<u8>) -> bool {
-        if !self.message_queue.contains_key(msg) {
+    fn can_sign(&self, encrypted_msg: &Vec<u8>) -> bool {
+        if !self.message_queue.contains_key(encrypted_msg) {
             return false;
         }
-        self.message_queue[msg].len() >= self.threshold as usize
+        self.message_queue[encrypted_msg].len() >= self.threshold as usize
     }
 
-    fn approve(&mut self, msg: Vec<u8>, signer: Principal) -> Result<u8, WalletError> {
-        if !self.message_queue.contains_key(&msg) {
+    async fn approve(&mut self, msg: Vec<u8>, wallet_id: &str) -> Result<u8, WalletError> {
+        let signer = ic_cdk::api::msg_caller();
+        let (encrypted_principal, encrypted_message) =
+            encrypt_principal_and_message_with_vetkeys(signer, &msg, &wallet_id)
+                .await
+                .map_err(|_| WalletError::EncryptionError)?;
+
+        if !self.message_queue.contains_key(&encrypted_message) {
             return Err(WalletError::MsgNotQueued);
         }
-
-        if !self.signers.contains(&signer) {
+        if !self.has_encrypted_signer(&encrypted_principal) {
             return Err(WalletError::InvalidSignature);
         }
 
-        let queue = self.message_queue.get_mut(&msg).unwrap();
-        queue.push(signer);
+        let queue: &mut Vec<String> = self.message_queue.get_mut(&encrypted_message).unwrap();
+
+        if queue.contains(&encrypted_principal) {
+            return Err(WalletError::MsgAlreadySignedBySigner);
+        }
+
+        queue.push(encrypted_principal);
 
         Ok(queue.len() as u8)
     }
 
-    fn get_messages_to_sign(&self) -> Vec<Vec<u8>> {
-        self.message_queue
+    async fn get_messages_to_sign(&self, wallet_id: &str) -> Result<Vec<Vec<u8>>, String> {
+        let messages: Vec<Vec<u8>> = self
+            .message_queue
             .iter()
-            .filter(|(msg, _)| self.can_sign(msg))
+            .filter(|(encrypted_msg, _)| self.can_sign(encrypted_msg))
             .map(|(msg, _)| msg.clone())
-            .collect()
+            .collect();
+
+        if self.has_signer(wallet_id).await {
+            // Authorized - decrypt messages
+            let encrypted_hex_list: Vec<String> = messages.iter().map(hex::encode).collect();
+            match decrypt_messages_with_vetkeys(&encrypted_hex_list, wallet_id).await {
+                Ok(decrypted_messages) => Ok(decrypted_messages),
+                Err(_) => Ok(messages), // Fallback to encrypted
+            }
+        } else {
+            // Not authorized - return encrypted messages
+            Ok(messages)
+        }
     }
 
-    fn get_proposed_messages(&self) -> Vec<Vec<u8>> {
-        self.message_queue.keys().cloned().collect()
+    async fn get_proposed_messages(&self, wallet_id: &str) -> Result<Vec<Vec<u8>>, String> {
+        let messages: Vec<Vec<u8>> = self.message_queue.keys().cloned().collect();
+
+        if self.has_signer(wallet_id).await {
+            // Authorized - decrypt messages
+            let encrypted_hex_list: Vec<String> = messages.iter().map(hex::encode).collect();
+            match decrypt_messages_with_vetkeys(&encrypted_hex_list, wallet_id).await {
+                Ok(decrypted_messages) => Ok(decrypted_messages),
+                Err(_) => Ok(messages), // Fallback to encrypted
+            }
+        } else {
+            // Not authorized - return encrypted messages
+            Ok(messages)
+        }
     }
 
-    fn get_messages_with_signers(&self) -> Vec<(Vec<u8>, Vec<Principal>)> {
+    async fn get_messages_with_signers(
+        &self,
+        wallet_id: &str,
+    ) -> Result<Vec<(Vec<u8>, Vec<String>)>, String> {
+        let messages_with_signers: Vec<(Vec<u8>, Vec<String>)> = self
+            .message_queue
+            .iter()
+            .map(|(msg, signers)| (msg.clone(), signers.clone()))
+            .collect();
+
+        if self.has_signer(wallet_id).await {
+            // Authorized - decrypt both messages and signers
+            match decrypt_wallet_data(
+                &self.get_signers(),
+                &self.get_default_threshold(),
+                &self.get_encrypted_messages_with_signers(),
+                &self.get_all_metadata(),
+                wallet_id,
+            )
+            .await
+            {
+                Ok(decrypted_data) => {
+                    // Convert decrypted data back to Vec<(Vec<u8>, Vec<String>)>
+                    let mut result = Vec::new();
+                    for (decrypted_msg, decrypted_signers) in decrypted_data.message_queue {
+                        let signer_strings: Vec<String> = decrypted_signers
+                            .into_iter()
+                            .map(|p| p.to_string())
+                            .collect();
+                        result.push((decrypted_msg, signer_strings));
+                    }
+                    Ok(result)
+                }
+                Err(_) => Ok(messages_with_signers), // Fallback to encrypted
+            }
+        } else {
+            // Not authorized - return encrypted
+            Ok(messages_with_signers)
+        }
+    }
+
+    fn get_encrypted_messages_with_signers(&self) -> Vec<(Vec<u8>, Vec<String>)> {
         self.message_queue
             .iter()
             .map(|(msg, signers)| (msg.clone(), signers.clone()))
             .collect()
     }
 
-    fn add_metadata(
+    async fn add_metadata(
         &mut self,
         message: Vec<u8>,
         metadata: String,
-        caller: Principal,
+        wallet_id: &str,
     ) -> Result<(), String> {
-        if !self.signers.contains(&caller) {
+        let signer = ic_cdk::api::msg_caller();
+        let (encrypted_principal, encrypted_message) =
+            encrypt_principal_and_message_with_vetkeys(signer, &message, &wallet_id)
+                .await
+                .map_err(|_| "EncryptionError".to_string())?;
+
+        if !self.has_encrypted_signer(&encrypted_principal) {
             return Err("Cannot add metadata: No signer.".to_string());
         }
-        if !self.message_queue.contains_key(&message) {
+        if !self.message_queue.contains_key(&encrypted_message) {
             return Err("Cannot add metadata: Message not found.".to_string());
         }
-        if self.metadata.contains_key(&message) {
+        if self.metadata.contains_key(&encrypted_message) {
             return Err("Metadata already exists for this message".to_string());
         }
-        self.metadata.insert(message, metadata);
+        let encrypted_metadata = encrypt_metadata_with_vetkeys(metadata, wallet_id)
+            .await
+            .map_err(|_| "EncryptionError".to_string())?;
+        self.metadata.insert(encrypted_message, encrypted_metadata);
         Ok(())
     }
 
-    fn get_metadata(&self, message: Vec<u8>, caller: Principal) -> Option<&String> {
-        if !self.signers.contains(&caller) {
+    async fn get_metadata(&self, message: Vec<u8>, wallet_id: &str) -> Option<String> {
+        let signer = ic_cdk::api::msg_caller();
+
+        // Encrypt principal and message
+        let (encrypted_principal, encrypted_message) =
+            encrypt_principal_and_message_with_vetkeys(signer, &message, &wallet_id)
+                .await
+                .ok()?;
+
+        // Check if signer is authorized
+        if !self.has_encrypted_signer(&encrypted_principal) {
             return None;
         }
-        self.metadata.get(&message)
+
+        // Get encrypted metadata
+        let encrypted_metadata = self.metadata.get(&encrypted_message)?;
+
+        // Decrypt and return metadata
+        decrypt_metadata_with_vetkeys(&encrypted_metadata, wallet_id)
+            .await
+            .ok()
     }
 
-    fn remove_message_and_metadata(
+    fn get_all_metadata(&self) -> HashMap<Vec<u8>, String> {
+        self.metadata
+            .iter()
+            .map(|(msg, meta)| (msg.clone(), meta.clone()))
+            .collect()
+    }
+
+    async fn remove_message_and_metadata(
         &mut self,
         msg: Vec<u8>,
-        caller: Principal,
+        wallet_id: &str,
     ) -> Result<(), String> {
+        let signer = ic_cdk::api::msg_caller();
+        let (encrypted_principal, encrypted_message) =
+            encrypt_principal_and_message_with_vetkeys(signer, &msg, &wallet_id)
+                .await
+                .map_err(|_| "EncryptionError".to_string())?;
+
         // Check if the caller is a signer
-        if !self.signers.contains(&caller) {
+        if !self.has_encrypted_signer(&encrypted_principal) {
             return Err("CallerNotSigner".to_string());
         }
 
         // Remove the message and its metadata
-        self.message_queue.remove(&msg);
-        self.metadata.remove(&msg);
+        self.message_queue.remove(&encrypted_message);
+        self.metadata.remove(&encrypted_message);
 
         Ok(())
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use candid::Principal;
-    use std::str::FromStr;
-
-    #[test]
-    fn test_default_wallet() {
-        let wallet = Wallet::default();
-        assert_eq!(wallet.get_signers().len(), 0);
-        assert_eq!(wallet.get_default_threshold(), 0);
-    }
-
-    #[test]
-    fn test_add_remove_signer() {
-        let mut wallet = Wallet::default();
-
-        let signer1 = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        let signer2 = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
-
-        wallet.add_signer(signer1);
-        wallet.add_signer(signer2);
-
-        let signers = wallet.get_signers();
-        assert_eq!(signers.len(), 2);
-        assert!(signers.contains(&signer1));
-        assert!(signers.contains(&signer2));
-
-        wallet.remove_signer(signer1);
-        let signers = wallet.get_signers();
-        assert_eq!(signers.len(), 1);
-        assert!(!signers.contains(&signer1));
-        assert!(signers.contains(&signer2));
-    }
-
-    #[test]
-    fn test_set_get_default_threshold() {
-        let mut wallet = Wallet::default();
-
-        assert_eq!(wallet.get_default_threshold(), 0);
-
-        wallet.add_signer(Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap());
-        let _ = wallet.set_default_threshold(1);
-        assert_eq!(wallet.get_default_threshold(), 1);
-        assert_eq!(
-            wallet.set_default_threshold(2),
-            Err(WalletError::NotEnoughSigners)
-        );
-    }
-
-    #[test]
-    fn test_propose_message_valid_signature() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
-
-        let msg = vec![1, 2, 3];
-        let result = wallet.propose_message(signer, msg);
-
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_propose_message_invalid_signature() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        // Don't add the signer to the wallet.
-        // wallet.add_signer(signer.clone());
-
-        let msg = vec![1, 2, 3];
-        let result = wallet.propose_message(signer, msg.clone());
-
-        assert_eq!(result.err(), Some(WalletError::InvalidSignature));
-    }
-
-    #[test]
-    fn test_propose_message_duplicate_message() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
-
-        let msg = vec![1, 2, 3];
-        let _ = wallet.propose_message(signer, msg.clone());
-
-        // Try proposing the same message again.
-        let result = wallet.propose_message(signer, msg);
-
-        assert_eq!(result.err(), Some(WalletError::MsgAlreadyQueued));
-    }
-
-    #[test]
-    fn test_can_sign_threshold_not_met() {
-        let mut wallet = Wallet::default();
-
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
-        let _ = wallet.set_default_threshold(1);
-
-        let msg = vec![1, 2, 3];
-        let _ = wallet.propose_message(signer, msg.clone());
-
-        // Threshold is not met, so cannot sign.
-        let can_sign = wallet.can_sign(&msg.clone());
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use candid::Principal;
+//     use std::str::FromStr;
+
+//     #[test]
+//     fn test_default_wallet() {
+//         let wallet = Wallet::default();
+//         assert_eq!(wallet.get_signers().len(), 0);
+//         assert_eq!(wallet.get_default_threshold(), 0);
+//     }
+
+//     #[test]
+//     fn test_add_remove_signer() {
+//         let mut wallet = Wallet::default();
+
+//         let signer1 = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         let signer2 = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
+
+//         wallet.add_signer(signer1);
+//         wallet.add_signer(signer2);
+
+//         let signers = wallet.get_signers();
+//         assert_eq!(signers.len(), 2);
+//         assert!(signers.contains(&signer1));
+//         assert!(signers.contains(&signer2));
+
+//         wallet.remove_signer(signer1);
+//         let signers = wallet.get_signers();
+//         assert_eq!(signers.len(), 1);
+//         assert!(!signers.contains(&signer1));
+//         assert!(signers.contains(&signer2));
+//     }
+
+//     #[test]
+//     fn test_set_get_default_threshold() {
+//         let mut wallet = Wallet::default();
+
+//         assert_eq!(wallet.get_default_threshold(), 0);
+
+//         wallet.add_signer(Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap());
+//         let _ = wallet.set_default_threshold(1);
+//         assert_eq!(wallet.get_default_threshold(), 1);
+//         assert_eq!(
+//             wallet.set_default_threshold(2),
+//             Err(WalletError::NotEnoughSigners)
+//         );
+//     }
+
+//     #[test]
+//     fn test_propose_message_valid_signature() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
+
+//         let msg = vec![1, 2, 3];
+//         let result = wallet.propose_message(signer, msg);
+
+//         assert!(result.is_ok());
+//     }
+
+//     #[test]
+//     fn test_propose_message_invalid_signature() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         // Don't add the signer to the wallet.
+//         // wallet.add_signer(signer.clone());
+
+//         let msg = vec![1, 2, 3];
+//         let result = wallet.propose_message(signer, msg.clone());
+
+//         assert_eq!(result.err(), Some(WalletError::InvalidSignature));
+//     }
+
+//     #[test]
+//     fn test_propose_message_duplicate_message() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
+
+//         let msg = vec![1, 2, 3];
+//         let _ = wallet.propose_message(signer, msg.clone());
+
+//         // Try proposing the same message again.
+//         let result = wallet.propose_message(signer, msg);
+
+//         assert_eq!(result.err(), Some(WalletError::MsgAlreadyQueued));
+//     }
+
+//     #[test]
+//     fn test_can_sign_threshold_not_met() {
+//         let mut wallet = Wallet::default();
+
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
+//         let _ = wallet.set_default_threshold(1);
+
+//         let msg = vec![1, 2, 3];
+//         let _ = wallet.propose_message(signer, msg.clone());
+
+//         // Threshold is not met, so cannot sign.
+//         let can_sign = wallet.can_sign(&msg.clone());
 
-        assert!(!can_sign);
-    }
+//         assert!(!can_sign);
+//     }
 
-    #[test]
-    fn test_can_sign_message_not_queued() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
+//     #[test]
+//     fn test_can_sign_message_not_queued() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
 
-        let msg = vec![1, 2, 3];
+//         let msg = vec![1, 2, 3];
 
-        // Message is not in the queue, so cannot sign.
-        let can_sign = wallet.can_sign(&msg.clone());
+//         // Message is not in the queue, so cannot sign.
+//         let can_sign = wallet.can_sign(&msg.clone());
 
-        assert!(!can_sign);
-    }
+//         assert!(!can_sign);
+//     }
 
-    #[test]
-    fn test_approve_valid_message() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
-        let _ = wallet.set_default_threshold(1);
+//     #[test]
+//     fn test_approve_valid_message() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
+//         let _ = wallet.set_default_threshold(1);
 
-        let msg = vec![1, 2, 3];
-        wallet.propose_message(signer, msg.clone()).unwrap();
+//         let msg = vec![1, 2, 3];
+//         wallet.propose_message(signer, msg.clone()).unwrap();
 
-        assert!(!wallet.can_sign(&msg));
-        let result = wallet.approve(msg.clone(), signer);
+//         assert!(!wallet.can_sign(&msg));
+//         let result = wallet.approve(msg.clone(), signer);
+
+//         assert!(result.is_ok());
+//         assert!(wallet.can_sign(&msg));
+//     }
+
+//     #[test]
+//     fn test_approve_invalid_message() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
 
-        assert!(result.is_ok());
-        assert!(wallet.can_sign(&msg));
-    }
-
-    #[test]
-    fn test_approve_invalid_message() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
+//         let msg = vec![1, 2, 3];
 
-        let msg = vec![1, 2, 3];
+//         let result = wallet.approve(msg.clone(), signer);
 
-        let result = wallet.approve(msg.clone(), signer);
+//         assert_eq!(result.err(), Some(WalletError::MsgNotQueued));
+//     }
 
-        assert_eq!(result.err(), Some(WalletError::MsgNotQueued));
-    }
+//     #[test]
+//     fn test_approve_not_signer() {
+//         let mut wallet = Wallet::default();
+//         let signer1 = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         let signer2 = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
+//         let _ = wallet.set_default_threshold(1);
+//         wallet.add_signer(signer1);
+
+//         let msg = vec![1, 2, 3];
+//         wallet.propose_message(signer1, msg.clone()).unwrap();
+
+//         let result = wallet.approve(msg.clone(), signer2);
 
-    #[test]
-    fn test_approve_not_signer() {
-        let mut wallet = Wallet::default();
-        let signer1 = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        let signer2 = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
-        let _ = wallet.set_default_threshold(1);
-        wallet.add_signer(signer1);
-
-        let msg = vec![1, 2, 3];
-        wallet.propose_message(signer1, msg.clone()).unwrap();
+//         assert_eq!(result.err(), Some(WalletError::InvalidSignature));
+//     }
+
+//     #[test]
+//     fn test_has_signer() {
+//         let mut wallet = Wallet::default();
+//         let signer1 = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         let signer2 = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
+//         wallet.add_signer(signer1);
+
+//         assert!(wallet.has_signer(signer1));
+//         assert!(!wallet.has_signer(signer2));
+//     }
+
+//     #[test]
+//     fn test_get_messages() {
+//         let mut wallet = Wallet::default();
+//         let signer1 = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         let signer2 = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
+//         wallet.add_signer(signer1);
+//         wallet.add_signer(signer2);
+//         let _ = wallet.set_default_threshold(1);
+
+//         let msg1 = vec![1, 2, 3];
+//         let msg2 = vec![4, 5, 6];
+//         let msg3 = vec![7, 8, 9];
+//         wallet.propose_message(signer1, msg1.clone()).unwrap();
+//         wallet.propose_message(signer2, msg2.clone()).unwrap();
+//         wallet.propose_message(signer2, msg3.clone()).unwrap();
+
+//         wallet.approve(msg1.clone(), signer1).unwrap();
+//         wallet.approve(msg2.clone(), signer2).unwrap();
 
-        let result = wallet.approve(msg.clone(), signer2);
+//         let messages_to_sign = wallet.get_messages_to_sign();
 
-        assert_eq!(result.err(), Some(WalletError::InvalidSignature));
-    }
-
-    #[test]
-    fn test_has_signer() {
-        let mut wallet = Wallet::default();
-        let signer1 = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        let signer2 = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
-        wallet.add_signer(signer1);
-
-        assert!(wallet.has_signer(signer1));
-        assert!(!wallet.has_signer(signer2));
-    }
-
-    #[test]
-    fn test_get_messages() {
-        let mut wallet = Wallet::default();
-        let signer1 = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        let signer2 = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
-        wallet.add_signer(signer1);
-        wallet.add_signer(signer2);
-        let _ = wallet.set_default_threshold(1);
-
-        let msg1 = vec![1, 2, 3];
-        let msg2 = vec![4, 5, 6];
-        let msg3 = vec![7, 8, 9];
-        wallet.propose_message(signer1, msg1.clone()).unwrap();
-        wallet.propose_message(signer2, msg2.clone()).unwrap();
-        wallet.propose_message(signer2, msg3.clone()).unwrap();
+//         assert_eq!(messages_to_sign.len(), 2);
+//         assert!(messages_to_sign.contains(&msg1));
+//         assert!(messages_to_sign.contains(&msg2));
+
+//         let proposed_messages = wallet.get_proposed_messages();
 
-        wallet.approve(msg1.clone(), signer1).unwrap();
-        wallet.approve(msg2.clone(), signer2).unwrap();
+//         assert_eq!(proposed_messages.len(), 3);
+
+//         let all_messages_with_signers = wallet.get_messages_with_signers();
 
-        let messages_to_sign = wallet.get_messages_to_sign();
+//         assert_eq!(all_messages_with_signers.len(), 3);
+//         // TODO: encrypt signer first
+//         assert!(all_messages_with_signers.contains(&(msg1.clone(), vec![signer1.to_string()])));
+//         assert!(all_messages_with_signers.contains(&(msg2.clone(), vec![signer2.to_string()])));
+//         assert!(all_messages_with_signers.contains(&(msg3.clone(), vec![])));
+//     }
 
-        assert_eq!(messages_to_sign.len(), 2);
-        assert!(messages_to_sign.contains(&msg1));
-        assert!(messages_to_sign.contains(&msg2));
-
-        let proposed_messages = wallet.get_proposed_messages();
+//     #[test]
+//     fn test_add_metadata_valid() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
+
+//         let msg = vec![1, 2, 3];
+//         let _ = wallet.propose_message(signer, msg.clone());
 
-        assert_eq!(proposed_messages.len(), 3);
-
-        let all_messages_with_signers = wallet.get_messages_with_signers();
-
-        assert_eq!(all_messages_with_signers.len(), 3);
-        assert!(all_messages_with_signers.contains(&(msg1.clone(), vec![signer1])));
-        assert!(all_messages_with_signers.contains(&(msg2.clone(), vec![signer2])));
-        assert!(all_messages_with_signers.contains(&(msg3.clone(), vec![])));
-    }
-
-    #[test]
-    fn test_add_metadata_valid() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
-
-        let msg = vec![1, 2, 3];
-        let _ = wallet.propose_message(signer, msg.clone());
-
-        let result = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer);
-
-        assert!(result.is_ok());
-        assert_eq!(
-            wallet.get_metadata(msg.clone(), signer),
-            Some(&"metadata".to_string())
-        );
-    }
-
-    #[test]
-    fn test_add_metadata_invalid_message() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
-
-        let msg = vec![1, 2, 3];
-
-        let result = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer);
-
-        assert_eq!(
-            result.err(),
-            Some("Cannot add metadata: Message not found.".to_string())
-        );
-    }
-
-    #[test]
-    fn test_add_metadata_invalid_signer() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        let invalid_signer = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
-        wallet.add_signer(signer);
-
-        let msg = vec![1, 2, 3];
-        let _ = wallet.propose_message(signer, msg.clone());
-
-        let result = wallet.add_metadata(msg.clone(), "metadata".to_string(), invalid_signer);
-
-        assert_eq!(
-            result.err(),
-            Some("Cannot add metadata: No signer.".to_string())
-        );
-    }
-
-    #[test]
-    fn test_get_metadata_exists() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
-
-        let msg = vec![1, 2, 3];
-        let _ = wallet.propose_message(signer, msg.clone());
-        let _ = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer);
-
-        let result = wallet.get_metadata(msg.clone(), signer);
-
-        assert_eq!(result, Some(&"metadata".to_string()));
-    }
-
-    #[test]
-    fn test_get_metadata_not_exists() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
-
-        let msg = vec![1, 2, 3];
-        let _ = wallet.propose_message(signer, msg.clone());
-
-        let result = wallet.get_metadata(msg.clone(), signer);
-
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_get_metadata_returns_none_if_not_signer() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        let invalid_signer = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
-        wallet.add_signer(signer);
-
-        let msg = vec![1, 2, 3];
-        let _ = wallet.propose_message(signer, msg.clone());
-        let _ = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer);
-
-        let result = wallet.get_metadata(msg.clone(), invalid_signer);
-
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_add_metadata_only_once() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
-
-        let msg = vec![1, 2, 3];
-        let _ = wallet.propose_message(signer, msg.clone());
-
-        let result = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer.clone());
-        assert!(result.is_ok());
-        assert_eq!(
-            wallet.get_metadata(msg.clone(), signer),
-            Some(&"metadata".to_string())
-        );
-
-        // Try to add metadata again to the same message
-        let result = wallet.add_metadata(msg.clone(), "new metadata".to_string(), signer.clone());
-        assert_eq!(
-            result.err(),
-            Some("Metadata already exists for this message".to_string())
-        );
-    }
-
-    #[test]
-    fn test_remove_message_and_metadata() {
-        let mut wallet = Wallet::default();
-        let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
-        wallet.add_signer(signer);
-
-        let msg = vec![1, 2, 3];
-        let _ = wallet.propose_message(signer, msg.clone());
-        let _ = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer);
-
-        assert_eq!(
-            wallet.get_metadata(msg.clone(), signer),
-            Some(&"metadata".to_string())
-        );
-
-        let result = wallet.remove_message_and_metadata(msg.clone(), signer);
-
-        assert!(result.is_ok());
-        assert_eq!(wallet.get_metadata(msg.clone(), signer), None);
-        assert!(!wallet.message_queue.contains_key(&msg));
-    }
-}
+//         let result = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer);
+
+//         assert!(result.is_ok());
+//         assert_eq!(
+//             wallet.get_metadata(msg.clone(), signer),
+//             Some(&"metadata".to_string())
+//         );
+//     }
+
+//     #[test]
+//     fn test_add_metadata_invalid_message() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
+
+//         let msg = vec![1, 2, 3];
+
+//         let result = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer);
+
+//         assert_eq!(
+//             result.err(),
+//             Some("Cannot add metadata: Message not found.".to_string())
+//         );
+//     }
+
+//     #[test]
+//     fn test_add_metadata_invalid_signer() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         let invalid_signer = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
+//         wallet.add_signer(signer);
+
+//         let msg = vec![1, 2, 3];
+//         let _ = wallet.propose_message(signer, msg.clone());
+
+//         let result = wallet.add_metadata(msg.clone(), "metadata".to_string(), invalid_signer);
+
+//         assert_eq!(
+//             result.err(),
+//             Some("Cannot add metadata: No signer.".to_string())
+//         );
+//     }
+
+//     #[test]
+//     fn test_get_metadata_exists() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
+
+//         let msg = vec![1, 2, 3];
+//         let _ = wallet.propose_message(signer, msg.clone());
+//         let _ = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer);
+
+//         let result = wallet.get_metadata(msg.clone(), signer);
+
+//         assert_eq!(result, Some(&"metadata".to_string()));
+//     }
+
+//     #[test]
+//     fn test_get_metadata_not_exists() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
+
+//         let msg = vec![1, 2, 3];
+//         let _ = wallet.propose_message(signer, msg.clone());
+
+//         let result = wallet.get_metadata(msg.clone(), signer);
+
+//         assert_eq!(result, None);
+//     }
+
+//     #[test]
+//     fn test_get_metadata_returns_none_if_not_signer() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         let invalid_signer = Principal::from_str("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
+//         wallet.add_signer(signer);
+
+//         let msg = vec![1, 2, 3];
+//         let _ = wallet.propose_message(signer, msg.clone());
+//         let _ = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer);
+
+//         let result = wallet.get_metadata(msg.clone(), invalid_signer);
+
+//         assert_eq!(result, None);
+//     }
+
+//     #[test]
+//     fn test_add_metadata_only_once() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
+
+//         let msg = vec![1, 2, 3];
+//         let _ = wallet.propose_message(signer, msg.clone());
+
+//         let result = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer.clone());
+//         assert!(result.is_ok());
+//         assert_eq!(
+//             wallet.get_metadata(msg.clone(), signer),
+//             Some(&"metadata".to_string())
+//         );
+
+//         // Try to add metadata again to the same message
+//         let result = wallet.add_metadata(msg.clone(), "new metadata".to_string(), signer.clone());
+//         assert_eq!(
+//             result.err(),
+//             Some("Metadata already exists for this message".to_string())
+//         );
+//     }
+
+//     #[test]
+//     fn test_remove_message_and_metadata() {
+//         let mut wallet = Wallet::default();
+//         let signer = Principal::from_str("2chl6-4hpzw-vqaaa-aaaaa-c").unwrap();
+//         wallet.add_signer(signer);
+
+//         let msg = vec![1, 2, 3];
+//         let _ = wallet.propose_message(signer, msg.clone());
+//         let _ = wallet.add_metadata(msg.clone(), "metadata".to_string(), signer);
+
+//         assert_eq!(
+//             wallet.get_metadata(msg.clone(), signer),
+//             Some(&"metadata".to_string())
+//         );
+
+//         let result = wallet.remove_message_and_metadata(msg.clone(), signer);
+
+//         assert!(result.is_ok());
+//         assert_eq!(wallet.get_metadata(msg.clone(), signer), None);
+//         assert!(!wallet.message_queue.contains_key(&msg));
+//     }
+// }


### PR DESCRIPTION
The idea is:
1. Switch from sync to async, since we need to call the vetkey API (which is async).
2. Use wallet_id instead caller() for data encryption, because I want a shared key to decrypt all data of 1 wallet. Otherwise, we would need n separate signer encryptions, which would waste memory.

If you want to deploy it to mainnet, remember to add "init_arg = production" from dfx.json:
    "q3x_backend": {
      "candid": "src/q3x_backend/q3x_backend.did",
      "package": "q3x_backend",
      "type": "rust",
      "init_arg": "\"production\""
    },

Check full flow demo below:
https://www.loom.com/share/88f0ee7b604a4578b7253e487efc78d6?sid=a72eff55-4642-45ad-bc67-9e42ff75ecb7